### PR TITLE
Solve 12865 - hsusj996

### DIFF
--- a/problems/week1/12865/solution_12865_sejin.java
+++ b/problems/week1/12865/solution_12865_sejin.java
@@ -1,11 +1,11 @@
-package baekjoon;
+
 
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.StringTokenizer;
 
-public class prob12865_2 {
+public class solution_12865_sejin {
     static int N, K;
     static StringTokenizer st = null;
     static int[] dp;

--- a/problems/week1/12865/solution_sejin.java
+++ b/problems/week1/12865/solution_sejin.java
@@ -1,0 +1,44 @@
+package baekjoon;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class prob12865_2 {
+    static int N, K;
+    static StringTokenizer st = null;
+    static int[] dp;
+    static int[] w;
+    static int[] v;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        K = Integer.parseInt(st.nextToken());
+
+        dp = new int[K + 1];
+        w = new int[N];
+        v = new int[N];
+
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            w[i] = Integer.parseInt(st.nextToken());
+            v[i] = Integer.parseInt(st.nextToken());
+        }
+
+        for (int i = 0; i < N; i++) {
+            for (int j = K; j >= 0; j--) {
+                if (w[i] > j) {
+                    continue;
+                }
+
+                dp[j] = Math.max(dp[j], dp[j - w[i]] + v[i]);
+            }
+        }
+
+        System.out.println(dp[K]);
+    }
+}

--- a/problems/week1/1655/solution_1655_sejin.java
+++ b/problems/week1/1655/solution_1655_sejin.java
@@ -1,0 +1,49 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Collections;
+import java.util.PriorityQueue;
+
+public class solution_1655_sejin {
+  static StringBuilder result = new StringBuilder();
+  static PriorityQueue<Integer> maxHeap;
+  static PriorityQueue<Integer> minHeap;
+  static int N;
+  static int cnt;
+
+  public static void main(String[] args) throws NumberFormatException, IOException {
+    BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+    // 초기화
+    maxHeap = new PriorityQueue<>(Collections.reverseOrder());
+    minHeap = new PriorityQueue<>();
+    cnt = 0;
+
+    N = Integer.parseInt(br.readLine());
+    for (int i = 0; i < N; i++) {
+      int n = Integer.parseInt(br.readLine());
+
+      // 삽입
+      if (maxHeap.size() == minHeap.size()) {
+        maxHeap.add(n);
+      } else {
+        minHeap.add(n);
+      }
+
+      // 삽입 후 peek 검사
+      if (maxHeap.size() > 0 && minHeap.size() > 0) {
+        if (maxHeap.peek() > minHeap.peek()) {
+          int i1 = maxHeap.poll();
+          int i2 = minHeap.poll();
+
+          maxHeap.add(i2);
+          minHeap.add(i1);
+        }
+      }
+
+      result.append(maxHeap.peek()).append("\n");
+    }
+
+    System.out.println(result);
+  }
+}


### PR DESCRIPTION
# boj12865 - 평범한 배낭
0-1 knapsack의 일반적인 문제입니다. 0-1 knapsack은 백트래킹, DP를 통해 풀이할 수 있지만 백트래킹의 경우 시간복잡도 2^n 을 가지기 때문에 DP로 풀이하는게 유리합니다.

2차원 DP 테이블 dp[N][K]이 있을때 N은 고려한 물건의 개수, K는 제한무게를 의미합니다. 이중for문을 통해 첫번째 물건을 무게가 1인 가방에 넣는 경우 (1, 1) 부터 (N, K) 까지 bottom-up 방식으로 수행합니다.

예를 들어, (i, j)의 경우 i번째 물건의 무게가 j보다 작다면 포함될 수 있기에 가능한 가치값은 V[i] + dp[i-1][K-W[i]] 입니다. 반대로 포함될 수 없다면 가치값은 dp[i-1][K] 입니다. 이 두 경우를 비교해 큰 값을 취하여 각 순서쌍에 대한 가치의 최대값을 구할 수 있습니다.

## 최적화 방법 (추가)
풀이와 같이 NxK의 배열을 만들수도 있지만 이를 최적화하면 2xK 배열로도 할 수 있습니다.

위의 풀이대로 dp[i][j]를 판단할 때 필요한 값은 i-1의 배열 정보입니다. 따라서, 이전 행 배열을 가져가면서 for문을 수행하면 공간복잡도를 최적화할 수 있습니다.

사실, 1xK 배열로도 풀이할 수 있습니다. 마찬가지로 이중for문을 활용하지만 (1, K) ~ (N, 0) 까지 순서쌍의 순회를 다르게 해야합니다. 

K부터 순회하는 이유는 위에서 설명했듯이 갱신에 필요한 값은 이전 행의 정보이며 이를 활용하기 위해서는 뒤에서부터 탐색하여 갱신되지 않은 앞의 정보를 이용해야 하기 때문입니다.