### PR TITLE
Solve 3197, 10830

### DIFF
--- a/problems/week1/10830/Solution_MW.java
+++ b/problems/week1/10830/Solution_MW.java
@@ -1,0 +1,67 @@
+package problems;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class Solution_MW {
+
+    static int n;
+    static long b;
+    public static void main(String[] args) throws IOException {
+
+        BufferedReader br = new BufferedReader(new InputStreamReader( System.in));
+        String[] s = br.readLine().split(" ");
+
+        n = Integer.parseInt(s[0]);
+        b = Long.parseLong(s[1]);
+
+        int[][] A = new int[n][n];
+        for(int i=0; i<n; i++) {
+            s = br.readLine().split(" ");
+            for(int j=0; j<n;  j++) {
+                A[i][j] = Integer.parseInt(s[j]);
+            }
+        }
+
+        int[][] res = matrixPow(A, b);
+        for(int i=0; i<n; i++) {
+            for(int j=0; j<n; j++) {
+                System.out.print(res[i][j] + " ");
+            }
+            System.out.println();
+        }
+    }
+
+    static int[][] matrixPow(int[][] B, long p) {
+
+        if(p == 1) {
+            for(int i=0; i<n; i++) {
+                for(int j=0; j<n; j++) {
+                    B[i][j] = B[i][j] % 1000;
+                }
+            }
+            return B;
+        }
+
+        int[][] tmp = matrixPow(B, p/2);
+        if(p % 2 == 0) { // 짝수승일 때
+            return matrixMul(tmp, tmp);
+        } else {
+            return matrixMul(matrixMul(tmp, tmp), B);
+        }
+    }
+
+    static int[][] matrixMul(int[][] a, int[][] b) {
+        int[][] res = new int[n][n];
+        for(int i=0; i<n; i++) {
+            for(int j=0; j<n; j++) {
+                for(int k=0; k<n; k++) {
+                    res[i][j] += ((a[i][k] * b[k][j]) % 1000);
+                    res[i][j] %= 1000;
+                }
+            }
+        }
+        return res;
+    }
+}

--- a/problems/week1/3197/Solution_MW.java
+++ b/problems/week1/3197/Solution_MW.java
@@ -1,0 +1,165 @@
+package problems;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
+
+public class Solution_mw {
+
+    public static class Pair {
+        public int y, x;
+
+        public Pair(int y, int x) {
+            this.y = y;
+            this.x = x;
+        }
+    }
+
+    static int r, c;
+    static char[][] board;
+    static int[][] water;
+    static int[] p;
+    static int[] dy = {-1, 0, 1, 0};
+    static int[] dx = {0, -1, 0, 1};
+    public static void main(String[] args) throws IOException {
+
+        // 두 백조가 있는 물 공간이 합쳐지면 된다
+        // 1. 각 백조가 있는 물 공간 좌표에 번호를 붙이기
+        // 2. 물 공간 영역 확장하기
+        // 3. 확장한 영역과 인접한 좌표의 물 공간 번호를 union 하기
+        // 4. 1번과 2번 물 공간 영역이 같은 공간에 있으면 종료
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        String[] s = br.readLine().split(" ");
+        r = Integer.parseInt(s[0]);
+        c = Integer.parseInt(s[1]);
+        board = new char[r][c];
+        water = new int[r][c];
+        p = new int[r*c];
+        List<Pair> ducks = new ArrayList<>();
+
+        for(int i=0; i<r; i++) {
+            String line = br.readLine();
+            for(int j=0; j<c; j++) {
+                board[i][j] = line.charAt(j);
+                if(board[i][j] == 'L') {
+                    ducks.add(new Pair(i, j));
+                }
+            }
+        }
+
+        // 물 공간 좌표에 번호 붙이기
+        int num = 1;
+        for(int i=0; i<r; i++) {
+            for (int j=0; j<c; j++) {
+                if(board[i][j] == 'X' || water[i][j] != 0)    continue;
+                bfs(i, j, num++);
+            }
+        }
+
+        // printForDebug();
+
+        // 초기 물 공간 큐에 넣기
+        Queue<Pair> q = new ArrayDeque<>();
+        for(int i=0; i<r; i++) {
+            for(int j=0; j<c; j++) {
+                if(board[i][j] == 'X')  continue;
+                q.add(new Pair(i, j));
+            }
+        }
+
+        // 물 공간 영역 확장하기
+        makeSet();
+        int days = 0;
+        while(true) {
+            // 두 백조가 있는 물 공간 영역이 같으면 종료
+            Pair duck1 = ducks.get(0);
+            Pair duck2 = ducks.get(1);
+            int num1 = water[duck1.y][duck1.x];
+            int num2 = water[duck2.y][duck2.x];
+            if(find(num1) == find(num2)) {
+                System.out.println(days);
+                break;
+            }
+
+            // 인접한 물 영역 확장
+            int qsize = q.size();
+            while(qsize-- > 0) {
+
+                Pair cur = q.poll();
+                for(int dir=0; dir<4; dir++) {
+                    int ny = cur.y + dy[dir];
+                    int nx = cur.x + dx[dir];
+                    if(ny < 0 || ny >= r || nx < 0 || nx >= c)  continue;
+                    if(board[ny][nx] != 'X')    continue;
+                    q.offer(new Pair(ny, nx));
+                    water[ny][nx] = water[cur.y][cur.x];
+                    board[ny][nx] = '.';
+                }
+            }
+
+            // 확장한 영역과 인접한 좌표의 물 공간 번호를 union 하기
+            qsize = q.size();
+            while(qsize-- > 0) {
+                Pair cur = q.poll();
+                for(int dir=0; dir<4; dir++) {
+                    int ny = cur.y + dy[dir];
+                    int nx = cur.x + dx[dir];
+                    if(ny < 0 || ny >= r || nx < 0 || nx >= c)  continue;
+                    if(board[ny][nx] == 'X' || water[cur.y][cur.x] == water[ny][nx])    continue;
+                    union(water[cur.y][cur.x], water[ny][nx]);
+                }
+                q.offer(cur);
+            }
+            days++;
+        }
+    }
+
+    static void printForDebug() {
+        for(int i=0; i<r; i++) {
+            for(int j=0; j<c; j++) {
+                System.out.print(water[i][j]);
+            }
+            System.out.println();
+        }
+    }
+
+    static void bfs(int i, int j, int num) {
+        Queue<Pair> q = new ArrayDeque<>();
+        q.offer(new Pair(i, j));
+        water[i][j] = num;
+        while(!q.isEmpty()) {
+            Pair cur = q.poll();
+            for(int dir=0; dir<4; dir++) {
+                int ny = cur.y + dy[dir];
+                int nx = cur.x + dx[dir];
+                if(ny < 0 || ny >= r || nx < 0 || nx >= c)  continue;
+                if(board[ny][nx] == 'X' || water[ny][nx] != 0)  continue;
+                q.offer(new Pair(ny, nx));
+                water[ny][nx] = num;
+            }
+        }
+    }
+
+    static void makeSet() {
+        for(int i=0; i<r*c; i++) {
+            p[i] = i;
+        }
+    }
+
+    static int find(int a) {
+        if(p[a] == a)   return a;
+        return p[a] = find(p[a]);
+    }
+
+    static void union(int a, int b) {
+        int rootA = find(a);
+        int rootB = find(b);
+        if (rootA == rootB) return;
+        p[rootA] = rootB;
+    }
+}


### PR DESCRIPTION
**문제이름: 3197 백조의 호수**

**작성자: kmw**

**문제 풀이**
- 물의 영역을 BFS를 통해 번호를 매깁니다.
- 물 영역을 확장합니다.
- 확장 후 두 물 영역이 합쳐졌는지 확인합니다.
- 합쳐졌다면 하나의 집합으로 union합니다.
- 위 사이클 반복마다 두 백조가 있는 물 영역이 같은 집합에 속하는지 확인합니다.

**리뷰**
- 다시 푸는 문제인데 푸는데 오래 걸렸습니다. 이유는 다음과 같습니다.
 1. 물 영역을 백조가 있는 2개 밖에 없다고 생각하고 풀이하였습니다. 따라서 물 영역 번호가 1, 2 두 개 밖에 없다고 생각하고 풀이했습니다.
 2. union할 때 두 노드의 root를 찾아서 union 해줘야 하는데, 저는 두 노드를 바로 union했습니다. 결과는 시간초과.. 디버깅 할 때 한참 찾은.. 부분입니다.

**문제이름: 10830 행렬 제곱**

**작성자: kmw**

**문제 풀이**
- 실수 거듭 제곱 구현과 크게 다르지 않습니다.
- 대신 행렬 곱셈을 정의하는 matrixMul 함수를 구현해줘야 합니다. 3중 for문으로 간단하게 구현이 가능합니다.
- 마지막 결과에 % 1000을 해주도록 합니다.

**리뷰**
- 거듭 제곱만 잘 구현한다면 쉽게 풀 수 있을거라고 생각합니다.