### PR TITLE
Solve 6087

### DIFF
--- a/problems/week2/6087/solution_6087_sj.java
+++ b/problems/week2/6087/solution_6087_sj.java
@@ -1,0 +1,130 @@
+package baekjoon;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+public class prob6087 {
+    static final int[][] d = { { 0, -1, 0, 1, 0 }, { 0, 0, 1, 0, -1 } };
+    static final int INF = 1_000_000;
+
+    static class Point implements Comparable<Point> {
+        int x;
+        int y;
+        int prevDirection;
+        int depth;
+
+        public Point(int x, int y, int prevDirection, int depth) {
+            this.x = x;
+            this.y = y;
+            this.prevDirection = prevDirection;
+            this.depth = depth;
+        }
+
+        @Override
+        public int compareTo(Point o) {
+            return this.depth - o.depth;
+        }
+
+    }
+
+    static final int GND = 0;
+    static final int WALL = 1;
+    static StringTokenizer st = null;
+    static int W, H;
+    static int[][] board;
+    static Point c1;
+    static Point c2;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        st = new StringTokenizer(br.readLine());
+        W = Integer.parseInt(st.nextToken());
+        H = Integer.parseInt(st.nextToken());
+
+        board = new int[H][W];
+        for (int i = 0; i < H; i++) {
+            String input = br.readLine();
+            for (int j = 0; j < W; j++) {
+                switch (input.charAt(j)) {
+                    case 'C':
+                        if (c1 == null) {
+                            c1 = new Point(i, j, 0, 0);
+                        } else {
+                            c2 = new Point(i, j, 0, 0);
+                        }
+                    case '.':
+                        board[i][j] = GND;
+                        break;
+                    case '*':
+                        board[i][j] = WALL;
+                        break;
+                }
+            }
+        }
+
+        System.out.println(bfs());
+    }
+
+    private static int bfs() {
+        int[][] result = new int[H][W];
+        for (int i = 0; i < H; i++) {
+            Arrays.fill(result[i], INF);
+        }
+
+        PriorityQueue<Point> q = new PriorityQueue<>();
+        boolean[][][] visited = new boolean[H][W][5];
+        result[c1.x][c1.y] = 0;
+        q.add(c1);
+
+        while (!q.isEmpty()) {
+            Point cur = q.poll();
+
+            if(visited[cur.x][cur.y][cur.prevDirection]){
+                continue;
+            }
+            visited[cur.x][cur.y][cur.prevDirection] = true;
+
+            for (int i = 1; i < 5; i++) {
+                int nx = cur.x + d[0][i];
+                int ny = cur.y + d[1][i];
+
+                if (IsOutBound(nx, ny) || board[nx][ny] == WALL) {
+                    continue;
+                }
+
+                int distance = 0;
+                if (cur.prevDirection == 0 || cur.prevDirection == i) {
+                    distance = cur.depth;
+                } else {
+                    distance = cur.depth + 1;
+                }
+
+                if(result[nx][ny] >= distance){
+                    result[nx][ny] = distance;
+                    q.add(new Point(nx, ny, i, distance));
+                }
+            }
+        }
+        // PrintForDebug(result);
+        return result[c2.x][c2.y];
+    }
+
+    private static void PrintForDebug(int[][] result) {
+        for (int i = 0; i < H; i++) {
+            for (int j = 0; j < W; j++) {
+                System.out.print(result[i][j] + " ");
+            }
+            System.out.println();
+        }
+        System.out.println("\n\n");
+    }
+
+    private static boolean IsOutBound(int nx, int ny) {
+        return nx < 0 || nx >= H || ny < 0 || ny >= W;
+    }
+}


### PR DESCRIPTION
## 문제 설명
<!-- 해결하려는 문제에 대한 간략한 설명을 작성합니다. 예를 들어, 문제 출처와 문제 번호, 문제 이름 등을 적습니다. -->
<!-- 각 항목의 내용은 필수가 아닙니다!! 자유롭게 작성해주세요!! -->

- 문제 출처: [백준](https://www.acmicpc.net/problem/6087)
- 문제 번호: #6087
- 문제 이름: 레이저 통신

## 해결 방법
<!-- 문제를 해결하기 위해 사용한 알고리즘과 접근 방법을 설명합니다. 주요 아이디어와 알고리즘의 흐름을 간략히 적어주세요. -->

- 사용한 알고리즘: BFS, 데이크스트라
- 접근 방법:
거울은 레이저의 진행 방향을 90도 바꿀 수 있습니다. 이를 통해 레이저끼리 연결해야 합니다. 일반적으로 격자에서 한 점과 다른 점이 만나는 경우에는 최소 거리를 BFS로 구합니다. 하지만 본 문제의 경우에는 거리가 얼마나 떨어져 있는지는 관심 없습니다. 구해야 하는 것은 거울의 최소 개수입니다.

그렇다면 거울의 개수를 어떻게 구해야 할까요? 거울은 레이저의 방향을 바꿀 때 사용됩니다. 따라서, BFS 진행 시에 만일 현재 진행 방향과 다음 진행 방향이 다르다면 거울을 설치해 가중치를 1만큼 더하면 되겠습니다.

또한, BFS는 이동 횟수가 아닌 거울의 개수를 중심으로 진행되어야 합니다. 거울을 설치하냐, 아니냐에 따라서 가중치가 달라집니다. 따라서, PriorityQueue를 이용해 사용한 거울의 수를 기준으로 정렬하여 상대적으로 적은 경우를 먼저 탐색하도록 해야합니다.

그렇다면 BFS의 방문처리는 어떻게 하면 될까요? 방문처리를 단순하게 좌표를 기준으로 한다면 최소인 경우가 포함되지 않을 수도 있습니다. (예를 들어, 특정 좌표에 거울을 사용해 접근하는 경우, 그렇지 않은 경우가 각각 존재할 때 전자의 경우가 먼저 수행되면 최소 가중치가 기록되지 않습니다.)

이러한 오류를 방지하기 위해 방문처리를 좌표, 그리고 방향을 기준으로 해결해야 합니다. 3차원 배열을 통해 [row][col][direction]으로 해결할 수 있습니다. 같은 좌표라도 이전에 다른 방향으로 접근했더라면 다른 경우로 생각해야 합니다.

여기까지 정리하자면,
1. BFS 진행 시 레이저의 진행 방향을 고려하자.
2. 현재와 다음의 진행방향이 다르다면 가중치를 1 추가하자.
3. BFS의 가중치가 0과 1로 구성되어 있기 때문에 pq를 사용하자.
4. 최소값을 기록하기 위해 3차원 방문 배열을 사용하자.

## 코드 설명
<!-- 작성한 코드의 주요 부분을 설명합니다. 복잡한 부분이나 중요한 로직에 대해 자세히 적어주세요. -->

- 주요 함수 및 변수:
