### PR TITLE
Solve 9376

### DIFF
--- a/problems/week2/9376/Solution_9376_MW.java
+++ b/problems/week2/9376/Solution_9376_MW.java
@@ -1,0 +1,163 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.*;
+
+
+public class Solution_9376_MW_2 {
+
+    static class Pair implements Comparable<Pair> {
+        public int y, x, door;
+
+        public Pair(int y, int x, int door) {
+            this.y = y;
+            this.x = x;
+            this.door = door;
+        }
+
+        @Override
+        public int compareTo(Pair o) {
+            return this.door - o.door;
+        }
+    }
+
+    static int T;
+    static int h, w;
+    static char[][] board;
+    static int[] dy = {-1, 0, 1, 0};
+    static int[] dx = {0, -1, 0, 1};
+
+    public static void main(String[] args) throws Exception {
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        T = Integer.parseInt(br.readLine());
+
+        for (int t = 1; t <= T; t++) {
+            String[] s = br.readLine().split(" ");
+            h = Integer.parseInt(s[0]);
+            w = Integer.parseInt(s[1]);
+
+            board = new char[h + 2][w + 2];
+            List<Pair> prisoner = new ArrayList<>();
+
+            for (int i = 1; i <= h; i++) {
+                String line = br.readLine();
+                for (int j = 1; j <= w; j++) {
+                    board[i][j] = line.charAt(j - 1);
+                    if (board[i][j] == '$') {
+                        prisoner.add(new Pair(i, j, 0));
+                    }
+                }
+            }
+
+            for (int i = 0; i <= h + 1; i++) { // 상근이가 돌아다닐 수 있도록, 감옥 외부에 패딩을 줌
+                if (i == 0 || i == h + 1) {
+                    for (int j = 0; j <= w + 1; j++) {
+                        board[i][j] = '.';
+                    }
+                } else {
+                    board[i][0] = '.';
+                    board[i][w + 1] = '.';
+                }
+            }
+
+            if (bfs(prisoner.get(0)) && bfs(prisoner.get(1))) { // 문을 열지 않고 갈 수 있는 경우 확인
+                System.out.println(0);
+                continue;
+            }
+
+            int[][] cost1 = dijkstra(new Pair(0, 0, 0)); // 상근이가 감옥을 돌면서 각 좌표에 도달하기 위해 문을 여는 최소 횟수 세기
+            int[][] cost2 = dijkstra(prisoner.get(0)); // 죄수1이 감옥을 돌면서 각 좌표에 도달하기 위해 문을 여는 최수 횟수 세기
+            int[][] cost3 = dijkstra(prisoner.get(1)); // 죄수2가 감옥을 돌면서 각 좌표에 도달하기 위해 문을 여는 최소 횟수 세기
+
+            // 문제 조건에서 "각 죄수와 감옥의 바깥을 연결하는 경로가 항상 존재하는 경우만 입력으로 주어진다."라고 하였으니 세 명은 반드시 만날 수 있다.
+            // 상근이와 만날 수 있다면 탈출한 것과 같다.
+            // 따라서 모든 좌표에 대해 상근, 죄수1, 죄수2가 해당 좌표에 도달하기 위해 문을 여는 최소 횟수를 구한다.
+            // 이후, 각 좌표에서 세 명의 문을 여는 횟수를 모두 더하고, -2를 해주면 그 좌표에서 만날 때 문을 연 최소 횟수가 된다.
+
+            int mn = Integer.MAX_VALUE;
+            for (int i = 0; i <= h+1; i++) {
+                for (int j = 0; j <= w+1; j++) {
+
+                    if (board[i][j] == '*') continue; // 벽일 경우
+
+                    int door = cost1[i][j] + cost2[i][j] + cost3[i][j]; // 각 사람이 해당 좌표로 가기 위한
+
+                    if (board[i][j] == '#') { // 세 명이므로 -2를 해서 중복을 제거
+                        door -= 2;
+                    }
+
+                    mn = Math.min(mn, door);
+                }
+            }
+            System.out.println(mn);
+        }
+    }
+
+    // 문을 열지 않고 두 죄수가 탈출할 수 있는지 확인
+    private static boolean bfs(Pair person) {
+        boolean[][] vis = new boolean[h + 2][w + 2];
+
+        Queue<Pair> q = new ArrayDeque<>();
+        q.offer(person);
+        vis[person.y][person.x] = true;
+
+        while (!q.isEmpty()) {
+            Pair cur = q.poll();
+//            System.out.println(cur.y + " " + cur.x);
+            for (int dir = 0; dir < 4; dir++) {
+                int ny = cur.y + dy[dir];
+                int nx = cur.x + dx[dir];
+                if (ny < 0 || ny >= h + 2 || nx < 0 || nx >= w + 2) {
+                    return true;
+                }
+                if (board[ny][nx] == '*' || board[ny][nx] == '#' || vis[ny][nx]) continue;
+                vis[ny][nx] = true;
+                q.offer(new Pair(ny, nx, 0));
+            }
+        }
+        return false;
+    }
+
+    // 상근, 죄수1, 죄수2가 모든 좌표에 도달할 때 문을 연 최소 개수를 기록
+    private static int[][] dijkstra(Pair person) {
+
+        int[][] cost = new int[h + 2][w + 2];
+        boolean[][] vis = new boolean[h + 2][w + 2];
+
+        for(int i=0; i<=h+1; i++) {
+            for(int j=0; j<=w+1; j++) {
+                cost[i][j] = Integer.MAX_VALUE;
+            }
+        }
+
+        PriorityQueue<Pair> pq = new PriorityQueue<>();
+        pq.offer(person);
+        cost[person.y][person.x] = 0;
+
+        while (!pq.isEmpty()) {
+            Pair minVertex = pq.poll();
+
+            if(vis[minVertex.y][minVertex.x])   continue;
+
+            vis[minVertex.y][minVertex.x] = true;
+
+            int door = minVertex.door;
+
+            for (int dir = 0; dir < 4; dir++) {
+                int ny = minVertex.y + dy[dir];
+                int nx = minVertex.x + dx[dir];
+                if (ny < 0 || ny >= h + 2 || nx < 0 || nx >= w + 2) continue;
+                if (board[ny][nx] == '*' || cost[ny][nx] <= cost[minVertex.y][minVertex.x]) continue; // 벽이거나 현재 vertex를 이용하여 최소값으로 업데이트 할 수 없으면
+                if (board[ny][nx] == '#') { // 문 일 경우, 현재 문의 개수 + 1
+                    cost[ny][nx] = cost[minVertex.y][minVertex.x] + 1;
+                    pq.offer(new Pair(ny, nx, door+1));
+                } else { // 문이 아니면, 현재 문의 개수 그대로 유지
+                    cost[ny][nx] = cost[minVertex.y][minVertex.x];
+                    pq.offer(new Pair(ny, nx, door));
+                }
+            }
+        }
+        return cost;
+    }
+}

--- a/problems/week2/9376/Solution_9376_MW_처음생각한풀이.java
+++ b/problems/week2/9376/Solution_9376_MW_처음생각한풀이.java
@@ -1,0 +1,163 @@
+/*
+ * 시간, 메모리 초과
+ * 먼저 한 죄수를 이동 시키고, 두번째 죄수를 이동 시키는 방법으로 했음.
+ * 한 죄수가 밖에 나가는 경우에 대하여, 문을 연 상태를 담은 배열을 2번째 죄수에게 넘겨주었음.
+ * 이 때 첫 번째 죄수는 나갈 수 있는 모든 경우를 탐색해야 하기 때문에 vis를 큐에 넣어서 같이 넘겨줌.
+ * 방문 체크가 매번 새로 이루어져서 중복되는 방문이 많아져서 시간 초과랑 메모리 초과가 발생하는 것 같음.
+ */
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Solution_9376_MW_처음생각한풀이 {
+
+    static class Pair {
+        public int y, x, cnt;
+        public boolean[][] isOpen;
+        public boolean[][] vis;
+        public Pair(int y, int x, int cnt, boolean[][] isOpen, boolean[][] vis) {
+            this.y = y;
+            this.x = x;
+            this.cnt = cnt;
+            this.isOpen = new boolean[h][w];
+            for(int i=0; i<h; i++) {
+                for(int j=0; j<w; j++) {
+                    this.isOpen[i][j] = isOpen[i][j];
+                }
+            }
+            this.vis = new boolean[h][w];
+            for(int i=0; i<h; i++) {
+                for(int j=0; j<w; j++) {
+                    this.vis[i][j] = vis[i][j];
+                }
+            }
+        }
+
+        public Pair(int y, int x, int cnt, boolean[][] isOpen) {
+            this.y = y;
+            this.x = x;
+            this.cnt = cnt;
+            this.isOpen = new boolean[h][w];
+            for(int i=0; i<h; i++) {
+                for(int j=0; j<w; j++) {
+                    this.isOpen[i][j] = isOpen[i][j];
+                }
+            }
+            this.vis = null;
+        }
+    }
+
+    static int T;
+    static int h, w;
+    static char[][] board;
+    static int[] dy = {-1, 0, 1, 0};
+    static int[] dx = {0, -1, 0, 1};
+    public static void main(String[] args) throws Exception {
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        T = Integer.parseInt(br.readLine());
+
+        for(int t=1; t<=T; t++) {
+            String[] s = br.readLine().split(" ");
+            h = Integer.parseInt(s[0]);
+            w = Integer.parseInt(s[1]);
+
+            board = new char[h][w];
+            List<Pair> people = new ArrayList<>();
+
+            for(int i=0; i<h; i++) {
+                String line = br.readLine();
+                for(int j=0; j<w; j++) {
+                    board[i][j] = line.charAt(j);
+                    if(board[i][j] == '$') {
+                        boolean[][] vis = new boolean[h][w];
+                        vis[i][j] = true;
+                        people.add(new Pair(i, j, 0, new boolean[h][w], vis));
+                    }
+                }
+            }
+
+            int sum = 0;
+            int mn = Integer.MAX_VALUE;
+
+            Queue<Pair> q = new ArrayDeque<>();
+            Pair p1 = people.get(0);
+            q.offer(p1);
+
+            while(!q.isEmpty()) {
+                Pair cur = q.poll();
+                boolean[][] isOpen = cur.isOpen;
+                boolean[][] vis = cur.vis;
+                int cnt = cur.cnt;
+                for(int dir=0; dir<4; dir++) {
+                    int ny = cur.y + dy[dir];
+                    int nx = cur.x + dx[dir];
+                    if(ny < 0 || ny >= h || nx < 0 || nx >= w) {
+                        Pair p2 = people.get(1);
+                        p2.isOpen = isOpen;
+                        sum += cur.cnt;
+                        int tmp = moveOtherPeople(p2);
+                        sum += tmp;
+                        mn = Math.min(mn, sum);
+                        sum = 0;
+                        continue;
+                    }
+                    if(board[ny][nx] == '*' || vis[ny][nx]) continue;
+                    if(board[ny][nx] == '#' && !isOpen[ny][nx]) {
+                        isOpen[ny][nx] = true;
+                        vis[ny][nx] = true;
+                        q.offer(new Pair(ny, nx, cnt + 1, isOpen, vis));
+                    } else {
+                        vis[ny][nx] = true;
+                        q.offer(new Pair(ny, nx, cnt, isOpen, vis));
+                    }
+                }
+            }
+
+            System.out.println(mn);
+        }
+    }
+
+    static int moveOtherPeople(Pair p2) {
+
+        int mn = Integer.MAX_VALUE;
+
+        boolean[][] vis = new boolean[h][w];
+
+        Queue<Pair> q = new ArrayDeque<>();
+        q.offer(p2);
+
+        vis[p2.y][p2.x] = true;
+
+        while(!q.isEmpty()) {
+            Pair cur = q.poll();
+            int cnt = cur.cnt;
+            boolean[][] isOpen = new boolean[h][w];
+            for(int i=0; i<h; i++) {
+                for(int j=0; j<w; j++) {
+                    isOpen[i][j] = cur.isOpen[i][j];
+                }
+            }
+            for(int dir=0; dir<4; dir++) {
+                int ny = cur.y + dy[dir];
+                int nx = cur.x + dx[dir];
+                if(ny < 0 || ny >= h || nx < 0 || nx >= w) {
+                    mn = Math.min(mn, cnt);
+                    continue;
+                }
+                if(board[ny][nx] == '*' || vis[ny][nx]) continue;
+                if(board[ny][nx] == '#' && !isOpen[ny][nx]) {
+                    isOpen[ny][nx] = true;
+                    vis[ny][nx] = true;
+                    q.offer(new Pair(ny, nx, cnt + 1, isOpen));
+                } else {
+                    vis[ny][nx] = true;
+                    q.offer(new Pair(ny, nx, cnt, isOpen));
+                }
+            }
+        }
+        return mn;
+    }
+}


### PR DESCRIPTION
## 문제 설명
<!-- 해결하려는 문제에 대한 간략한 설명을 작성합니다. 예를 들어, 문제 출처와 문제 번호, 문제 이름 등을 적습니다. -->
<!-- 각 항목의 내용은 필수가 아닙니다!! 자유롭게 작성해주세요!! -->

- 문제 출처: 백준 https://www.acmicpc.net/problem/9376
- 문제 번호: #9376
- 문제 이름: 탈옥

## 해결 방법
- 사용한 알고리즘: 다익스트라, BFS
- 접근 방법: 
   1. 상근이 감옥을 돌면서 각 좌표에 도달하기 위해 문을 여는 최소 횟수 세기
   2. 죄수1이 감옥을 돌면서 각 좌표에 도달하기 위해 문을 여는 최소 횟수 세기
   3. 죄수2가 감옥을 돌면서 각 좌표에 도달하기 위해 문을 여는 최소 횟수 세기
   5. board를 순회하면서 상근, 죄수1, 죄수2가 해당 좌표에 도달하기 위해 문을 여는 최소 횟수의 합을 구한다.
   6. 해당 좌표가 문일 경우, 세 명 각각이 해당 좌표로 이동하기 위해 필요한 문을 여는 횟수이므로 -2를 해서 중복을 제거해준다.
   7. 그중 최소값을 구한다.
   
## 리뷰
<!-- 작성한 코드의 주요 부분을 설명합니다. 복잡한 부분이나 중요한 로직에 대해 자세히 적어주세요. -->
- 세 명 각각을 다익스트라로 최단거리를 구해서, 더한 다음 -2 해주는 아이디어를 생각하는 것이 어려운 문제인 것 같습니다.
- 다익스트라를 오랫만에 푸니 기억이 잘 안났습니다.
  - 특히 ```cost[ny][nx] <= cost[minVertex.y][minVertex.x] ``` 이 부분은 다익스트라 알고리즘에서 핵심적인 내용인데, 빼먹어서 디버깅이 오래 걸렸습니다.
