### PR TITLE
Solve 11049

### DIFF
--- a/problems/week3/11049/solution_11049_sj.java
+++ b/problems/week3/11049/solution_11049_sj.java
@@ -1,0 +1,43 @@
+package baekjoon;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class prob11049_2 {
+  static final int INF = 1_000_000_000;
+  static StringTokenizer st = null;
+  static int[][] data;
+  static int N;
+  static int[][] dp;
+
+  public static void main(String[] args) throws NumberFormatException, IOException {
+    BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+    N = Integer.parseInt(br.readLine());
+
+    dp = new int[N + 1][N + 1];
+    data = new int[N + 1][2];
+    for (int i = 1; i <= N; i++) {
+      st = new StringTokenizer(br.readLine());
+      int r = Integer.parseInt(st.nextToken());
+      int c = Integer.parseInt(st.nextToken());
+
+      data[i][0] = r;
+      data[i][1] = c;
+    }
+
+    for (int i = 1; i <= N; i++) {
+      for (int j = i - 1; j >= 1; j--) {
+        dp[j][i] = INF;
+        for (int k = j; k < i; k++) {
+          int value = dp[j][k] + dp[k + 1][i] + (data[j][0] * data[k][1] * data[i][1]);
+          dp[j][i] = Math.min(dp[j][i], value);
+        }
+      }
+    }
+
+    System.out.println(dp[1][N]);
+  }
+}


### PR DESCRIPTION
## 문제 설명
<!-- 해결하려는 문제에 대한 간략한 설명을 작성합니다. 예를 들어, 문제 출처와 문제 번호, 문제 이름 등을 적습니다. -->
<!-- 각 항목의 내용은 필수가 아닙니다!! 자유롭게 작성해주세요!! -->

- 문제 출처: [백준](https://www.acmicpc.net/problem/11049)
- 문제 번호: #11049
- 문제 이름: 행렬 곱셈 순서

## 해결 방법
<!-- 문제를 해결하기 위해 사용한 알고리즘과 접근 방법을 설명합니다. 주요 아이디어와 알고리즘의 흐름을 간략히 적어주세요. -->

- 사용한 알고리즘: 다이나믹 프로그래밍
- 접근 방법:
행렬 곱셈이 가능한 행렬 집합 A, B, C가 있을 때 가능한 경우는 ((AxB)xC) 혹은 (Ax(BxC))가 있습니다. 무엇을 먼저 곱해야 연산 횟수가 최소가 되는지 알아야 합니다.

완전탐색의 시점으로 본다면 묶어서 곱할 2개의 행렬을 항상 선택해야 합니다. nC2 x (n-1)C2 * ...... 만큼 수행해야 합니다.

n은 최대 500이기 때문에 시간적으로 불가능합니다. 따라서, 다른 탐색 방법이 필요해보입니다.

DP의 시점으로 봅시다. DP 배열을 2차원으로 첫번째 인덱스는 왼쪽 한계선, 두번째 인덱스는 오른쪽 한계선으로 취급하면 우리가 구해야 할 정답은 DP[1][N]이 되겠습니다. (1부터 N까지의 행렬 곱셈의 최소 연산 수)

그럼 DP[1][N]은 1 <= x <= N 일때 DP[1][x] + DP[x][N] + data[1][0] x data[x][1] x data[N][1]이 됩니다. 가능한 x 중에서 최솟값을 선택해 DP[1][N]을 결정하면 됩니다.

## 코드 설명
<!-- 작성한 코드의 주요 부분을 설명합니다. 복잡한 부분이나 중요한 로직에 대해 자세히 적어주세요. -->

- 주요 함수 및 변수:
