### PR TITLE
Solve 7579

### DIFF
--- a/problems/week3/7579/Solution_7579_MW.java
+++ b/problems/week3/7579/Solution_7579_MW.java
@@ -1,0 +1,50 @@
+package problems;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+
+public class Solution_7579_MW {
+
+    static int N, M;
+    static int[] m;
+    static int[] c;
+    public static void main(String[] args) throws Exception {
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        String[] s = br.readLine().split(" ");
+        N = Integer.parseInt(s[0]);
+        M = Integer.parseInt(s[1]);
+
+        int[] m = new int[N+1];
+        int[] c = new int[N+1];
+        int[][] d = new int[N+1][10001]; // i번째 앱까지 고려하여 cost가 j일 때 확보한 메모리의 최대값
+
+        s = br.readLine().split(" ");
+        for(int i=1; i<=N; i++) {
+            m[i] = Integer.parseInt(s[i-1]);
+        }
+        s = br.readLine().split( " ");
+        int sum = 0;
+        for(int i=1; i<=N; i++) {
+            c[i] = Integer.parseInt(s[i-1]);
+            sum += c[i];
+        }
+
+        for(int cost=0; cost<=sum; cost++) {
+            for(int i=1; i<=N; i++) {
+                d[i][cost] = d[i-1][cost]; // 현재 앱을 비활성화 하지 않는 경우
+
+                if(cost >= c[i]) { // 비활성화 할 수 있는 경우
+                    d[i][cost] = Math.max(d[i][cost], d[i-1][cost-c[i]] + m[i]);
+                    // i번째 앱을 비활성화 하지 않는 것과 비활성화 하는 것을 비교하여 큰 값을 취함
+                }
+
+                if(d[i][cost] >= M) { // M보다 확보한 메모리가 커지면 cost 출력하고 종료 (최소 cost)
+                    System.out.println(cost);
+                    return;
+                }
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
## 문제 설명
<!-- 해결하려는 문제에 대한 간략한 설명을 작성합니다. 예를 들어, 문제 출처와 문제 번호, 문제 이름 등을 적습니다. -->
<!-- 각 항목의 내용은 필수가 아닙니다!! 자유롭게 작성해주세요!! -->

- 문제 출처: 백준 https://www.acmicpc.net/problem/7579
- 문제 번호: #7579
- 문제 이름: 앱

## 해결 방법
<!-- 문제를 해결하기 위해 사용한 알고리즘과 접근 방법을 설명합니다. 주요 아이디어와 알고리즘의 흐름을 간략히 적어주세요. -->

- 사용한 알고리즘: DP
- 접근 방법: 전형적인 DP 냅색 문제를 응용한 버전입니다. 보통 "**d[i][j]: i번째 앱까지 고려하여 확보한 메모리가 j바이트일 때 최소 비용**"이라고 점화식을 생각할  것입니다. 하지만 여기서 M=10^7이고 N=10^2이므로 위와 같이 점화식을 세운다면 메모리는 10^9 = 1GB를 사용하게 됩니다. 따라서 다른 방법을 찾아야 합니다.
- 생각을 조금 바꿔서 해보면 다음과 같이 점화식을 세울 수 있습니다. "**d[i][j]: i번째 앱까지 고려하여 비용이 j일 때 확보한 메모리의 최대값**" 이렇게 세운다면 10^2 * 10^4 = 10^6으로 효율적으로 메모리를 사용할 수 있습니다.
- 이후 전형적인 냅색 문제를 해결하면 됩니다.

## 리뷰
- 아직 Bottom-up 방식으로 생각하는데 익숙하지 않은 것 같습니다. DP 내용 복습하면서 이론적으로 익숙해질 때 까지 손으로 적어 본 다음에 적용 시키는 연습을 해야겠다고 생각했습니다.