### PR TITLE
Solve 7579

### DIFF
--- a/problems/week3/7579/solution_7579_sj.java
+++ b/problems/week3/7579/solution_7579_sj.java
@@ -1,0 +1,54 @@
+package baekjoon;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class prob7579 {
+    static StringTokenizer st = null;
+    static int N, M;
+    static int[] cost;
+    static int[] memory;
+    static int[][] dp;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        memory = new int[N + 1];
+        cost = new int[N + 1];
+
+        st = new StringTokenizer(br.readLine());
+        for (int i = 1; i <= N; i++) {
+            memory[i] = Integer.parseInt(st.nextToken());
+
+        }
+
+        st = new StringTokenizer(br.readLine());
+        for (int i = 1; i <= N; i++) {
+            cost[i] = Integer.parseInt(st.nextToken());
+        }
+
+        dp = new int[N + 1][10001];
+        for (int i = 1; i <= N; i++) {
+            for (int j = 0; j <= 10000; j++) {
+                if (j < cost[i]) {
+                    dp[i][j] = dp[i - 1][j];
+                } else {
+                    dp[i][j] = Math.max(dp[i - 1][j], dp[i - 1][j - cost[i]] + memory[i]);
+                }
+            }
+        }
+
+        for (int i = 0; i <= 10000; i++) {
+            if (dp[N][i] >= M) {
+                System.out.println(i);
+                break;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 문제 설명
<!-- 해결하려는 문제에 대한 간략한 설명을 작성합니다. 예를 들어, 문제 출처와 문제 번호, 문제 이름 등을 적습니다. -->
<!-- 각 항목의 내용은 필수가 아닙니다!! 자유롭게 작성해주세요!! -->

- 문제 출처: [백준](https://www.acmicpc.net/problem/7579)
- 문제 번호: #7579
- 문제 이름: 앱

## 해결 방법
<!-- 문제를 해결하기 위해 사용한 알고리즘과 접근 방법을 설명합니다. 주요 아이디어와 알고리즘의 흐름을 간략히 적어주세요. -->

- 사용한 알고리즘: DP, knapsack
- 접근 방법:

가장 직관적인 방법은 M 바이트를 확보하기 위해 N개의 앱간의 조합을 모두 탐색하는 것입니다. 하지만, 부분 집합의 경우 N이 최대 100개이기 때문에 2^100의 시간이 필요합니다.

따라서, 탐색을 최적화하는 DP를 사용해야 합니다. N개를 선택하여 최소 M 바이트를 선택한다? 바로 배낭문제와 유사합니다.

기존의 배낭 문제와 비교해봅시다. 배낭문제는 무게와 가치가 주어집니다. 제한된 무게 안에서 최대 가치를 구해야 합니다. 배낭 문제의 기본 DP 원리는 무게를 기준으로 어떠한 물건이 가방에 포함될 수 있는지에 대한 여부를 판단합니다. i번째, j무게를 판단할 때 만일 i번째 무게가 j보다 크다면 가방에 넣을 수 없기 때문에 i번째 물건은 제외해야 합니다. ~~반대로 가능하다면 i번째 물건을 넣은 채 DP테이블을 갱신합니다.~~ 가능한 경우에는 물건을 넣지 않는 경우와 비교해 더 작은 값으로 DP 테이블을 갱신합니다.


본 문제에 대입해봅시다. 먼저 메모리를 생각해봅시다. 제한된 메모리에 따라 앱이 포함될 수 있는지를 판단할 수 있을까요? 없습니다. 문제에서는 메모리는 최소 M바이트 이상이면 되기 때문에 메모리는 그 이상 포함되어도 문제의 조건에 만족합니다.

그렇다면 비용은 어떨까요? j의 비용에서 i번째 앱이 포함될 수 있는지 판단할 수 있을까요? 있습니다. 제한된 비용에 따라서 i번째 비용이 더 작다면 포함될 수 있고 없다면 포함될 수 없습니다. 본 문제에서의 비용이 곧 배낭 문제의 무게를 의미합니다.

문제의 조건을 보면 비용은 최대 100이며 앱도 최대 100개가 존재합니다. 따라서, 존재할 수 있는 비용 합의 최댓값은 100x100 입니다. 이를 활용하여 DP 테이블을 구성할 수 있습니다. 점화식은 배낭 문제의 점화식과 같습니다.

정답은 비용의 최솟값을 원하기 때문에 DP[N][j]가 M이상인 최소 j가 정답이 되겠습니다.

## 문제 리뷰
<!-- 문제에 대한 후기, 평가 기타 팁과 같이 자유롭게 작성해주세요. -->
배낭문제와 같지만 결론에 아이디어를 떠올리기까지 적지않은 시간이 걸린 것 같습니다. 
배낭문제는 DP, 그리디와 같이 문제에 따라 풀이방법이 다르기 때문에 익숙해져야 할 것 같습니다.
