### PR TITLE
Solve 1039

### DIFF
--- a/problems/week4/1039/solution_1039_sj.java
+++ b/problems/week4/1039/solution_1039_sj.java
@@ -1,0 +1,91 @@
+package baekjoon;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.Queue;
+import java.util.Scanner;
+
+public class prob1039 {
+    static class Node {
+        int a;
+        int b;
+        int result;
+
+        public Node(int a, int b, int result) {
+            this.a = a;
+            this.b = b;
+            this.result = result;
+        }
+    }
+
+    static boolean[][] visited;
+    static int A, B;
+    static int size;
+
+    public static void main(String[] args) {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        Scanner sc = new Scanner(System.in);
+        A = sc.nextInt();
+        B = sc.nextInt();
+        size = String.valueOf(A).length();
+        visited = new boolean[1_000_001][B + 1];
+
+        if (String.valueOf(A).length() == 1) {
+            System.out.println(-1);
+            return;
+        }
+
+        System.out.println(bfs());
+    }
+
+    private static int bfs() {
+        Queue<Integer> q = new ArrayDeque<>();
+        q.add(A);
+        visited[A][0] = true;
+        int depth = 0;
+
+        while (++depth <= B) {
+            int qsize = q.size();
+            while (qsize-- > 0) {
+                int cur = q.poll();
+
+                for (int i = 0; i < size; i++) {
+                    for (int j = i + 1; j < size; j++) {
+                        int result = Swap(cur, i, j);
+
+                        if (String.valueOf(result).length() != size || visited[result][depth]) {
+                            continue;
+                        }
+
+                        visited[result][depth] = true;
+                        q.add(result);
+                    }
+                }
+            }
+        }
+
+        if(q.size() == 0){
+            return -1;
+        }
+
+        int max = 0;
+        for (int n : q) {
+            max = Math.max(max, n);
+        }
+
+        return max;
+    }
+
+    private static int Swap(int n, int a, int b) {
+        String N = String.valueOf(n);
+
+        char[] cArr = N.toCharArray();
+        char tmp = cArr[a];
+        cArr[a] = cArr[b];
+        cArr[b] = tmp;
+
+        return Integer.parseInt(String.valueOf(cArr));
+    }
+}


### PR DESCRIPTION
## 문제 설명
<!-- 해결하려는 문제에 대한 간략한 설명을 작성합니다. 예를 들어, 문제 출처와 문제 번호, 문제 이름 등을 적습니다. -->
<!-- 각 항목의 내용은 필수가 아닙니다!! 자유롭게 작성해주세요!! -->

- 문제 출처: [백준](https://www.acmicpc.net/problem/1039)
- 문제 번호: #1039
- 문제 이름: 교환

## 해결 방법
<!-- 문제를 해결하기 위해 사용한 알고리즘과 접근 방법을 설명합니다. 주요 아이디어와 알고리즘의 흐름을 간략히 적어주세요. -->

- 사용한 알고리즘: BFS
- 접근 방법:

문제의 중요한 조건은 K번의 연산을 무조건 수행해야 한다는 것입니다. (132, 3)의 입력의 경우에는 132로 만들 수 있는 최대값은 321이지만 연산을 무조건 3번 수행해야 하기 때문에 이 때의 정답은 312가 되는 것입니다.

문제를 보았을 때 우선적으로는 최댓값을 만드는 것이기 때문에 그리디로 생각할수도 있지만 M이 최대 7 그리고 K가 최대 10이라는 것을 보면 완탐의 가능성을 확인할 수 있습니다.

완전탐색의 경우 시간복잡도를 분석해봅시다. 최대 7 자릿수에서 2개를 뽑고 그 과정을 K번 수행하면 됩니다.

7C2 ^ 10 = 1.6679881e+13

위와 같은 방법으로는 불가능해보입니다. 그렇다면 탐색의 과정에서 중복을 제거할 수 있는 방법을 찾아봅시다. 우선, 중복이 생기는 경우를 생각해보면, 탐색의 중복은 특정 횟수의 연산을 수행했을 때 과정이 어떻든 결과가 같은 경우에 해당합니다. 예를들어, a번 수행하면 132가 나왔다면 우리는 a번 이전에 어떻게 숫자를 교환했는지는 궁금하지 않습니다. 단지, a번 수행했을 때의 결과만이 중요합니다.

따라서, 완전탐색을 수행할 때 숫자와 연산횟수를 기준으로 방문처리를 하고 중복탐색을 제거하면 시간복잡도를 획기적으로 줄일 수 있을 것 같습니다.
(대충 계산해보면 N이 가능한 수의 갯수 * 연산 횟수로 1,000,000 x 10 즉, 1000만의 시간복잡도가 계산됩니다.)
(하지만, 실제로는 바꾼 수가 0이 될 수 없다는 조건 등으로 시간복잡도는 더 작습니다.)

## 문제 리뷰
<!-- 문제에 대한 후기, 평가 기타 팁과 같이 자유롭게 작성해주세요. -->
BFS를 어떻게 처리해야 효율적인지에 대한 문제가 많은 듯 합니다. BFS를 잘 이해하고 커스텀할 수 있는 능력이 중요해보입니다.