### PR TITLE
Solve 9370

### DIFF
--- a/problems/week4/9370/solution_9370_sj.java
+++ b/problems/week4/9370/solution_9370_sj.java
@@ -1,0 +1,118 @@
+package baekjoon;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+public class prob9370 {
+    static final int INF = 1_000_000_000;
+
+    static class Edge implements Comparable<Edge> {
+        int to;
+        int weight;
+
+        public Edge(int to, int weight) {
+            this.to = to;
+            this.weight = weight;
+        }
+
+        @Override
+        public int compareTo(Edge o) {
+            return this.weight - o.weight;
+        }
+
+    }
+
+    static int T;
+    static int n, m, t, s, g, h;
+    static List<Edge>[] graph;
+    static int[] minDistance;
+    static StringTokenizer st = null;
+    static boolean[] isDest;
+    static StringBuilder sb = new StringBuilder();
+
+    public static void main(String[] args) throws NumberFormatException, IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        T = Integer.parseInt(br.readLine());
+
+        for (int test_case = 1; test_case <= T; test_case++) {
+            st = new StringTokenizer(br.readLine());
+            n = Integer.parseInt(st.nextToken());
+            m = Integer.parseInt(st.nextToken());
+            t = Integer.parseInt(st.nextToken());
+
+            st = new StringTokenizer(br.readLine());
+            s = Integer.parseInt(st.nextToken());
+            g = Integer.parseInt(st.nextToken());
+            h = Integer.parseInt(st.nextToken());
+
+            graph = new ArrayList[n + 1];
+            for (int i = 1; i <= n; i++) {
+                graph[i] = new ArrayList<>();
+            }
+
+            for (int i = 0; i < m; i++) {
+                st = new StringTokenizer(br.readLine());
+                int a = Integer.parseInt(st.nextToken());
+                int b = Integer.parseInt(st.nextToken());
+                int weight = Integer.parseInt(st.nextToken());
+
+                if ((a == g && b == h) || (a == h && b == g)) {
+                    graph[a].add(new Edge(b, 2 * weight - 1));
+                    graph[b].add(new Edge(a, 2 * weight - 1));
+                }
+
+                graph[a].add(new Edge(b, 2 * weight));
+                graph[b].add(new Edge(a, 2 * weight));
+            }
+
+            isDest = new boolean[2001];
+            for (int i = 0; i < t; i++) {
+                isDest[Integer.parseInt(br.readLine())] = true;
+            }
+
+            dijkstra();
+
+            for (int i = 1; i <= n; i++) {
+                if (isDest[i] && minDistance[i] % 2 == 1) {
+                    sb.append(i).append(" ");
+                }
+            }
+            sb.append("\n");
+        }
+
+        System.out.println(sb.toString());
+    }
+
+    private static void dijkstra() {
+        boolean[] visited = new boolean[n + 1];
+        minDistance = new int[n + 1];
+        for (int i = 1; i <= n; i++) {
+            minDistance[i] = INF;
+        }
+        PriorityQueue<Edge> pq = new PriorityQueue<>();
+        pq.add(new Edge(s, 0));
+        minDistance[s] = 0;
+
+        while (!pq.isEmpty()) {
+            Edge cur = pq.poll();
+
+            if (visited[cur.to]) {
+                continue;
+            }
+            visited[cur.to] = true;
+
+            for (Edge e : graph[cur.to]) {
+                int distance = minDistance[cur.to] + e.weight;
+                if (minDistance[e.to] >= distance) {
+                    minDistance[e.to] = distance;
+                    pq.add(new Edge(e.to, distance));
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 문제 설명
<!-- 해결하려는 문제에 대한 간략한 설명을 작성합니다. 예를 들어, 문제 출처와 문제 번호, 문제 이름 등을 적습니다. -->
<!-- 각 항목의 내용은 필수가 아닙니다!! 자유롭게 작성해주세요!! -->

- 문제 출처: [백준](https://www.acmicpc.net/problem/9370)
- 문제 번호: #9370
- 문제 이름: 미확인 도착지

## 해결 방법
<!-- 문제를 해결하기 위해 사용한 알고리즘과 접근 방법을 설명합니다. 주요 아이디어와 알고리즘의 흐름을 간략히 적어주세요. -->

- 사용한 알고리즘: 데이크스트라
- 접근 방법:

일단 최단경로를 구해야하기 때문에 데이크스트라를 적용해야 하는 것으로 보입니다. 하지만 무조건 지나야 하는 간선이 존재하기 때문에 지나온 간선 정보가 필요해보입니다.

지나온 간선을 저장할 때는 일반적으로 최단경로일때의 이전에 지나온 노드를 기억할 배열을 생성합니다. 데이크스트라에서 만일 현재까지의 최단거리가 더 짧아 갱신이 가능하다면 현재 방문 노드를 지나가야 하기 때문에 방문 배열을 갱신합니다.

하지만 결론적으로 말하면 경로를 저장하는 방식의 풀이는 위 문제에 적용될 수 없습니다. 왜냐하면 최단경로가 2개 이상인 경우도 있을 수 있는데, 항상 기록되는 경로는 1개이기 때문입니다. (실제로 간선이 포함된 경로가 최단경로지만 기록되지 않을 수도 있습니다.)

이 다음의 아이디어는 생각나지 않아 다른 코드들을 보면서 답안을 참고했습니다.

주요 풀이방법은 크게 2가지 입니다.

**최단거리의 합으로 간선이 지나온 지 확인하기**
문제에서는 무조건 지나야 하는 간선을 g, h로 주어집니다. 우리는 해당 간선을 무조건 지나는 도착지 후보들을 찾아야 합니다. 이를 역으로 생각해봅시다. 정답이 되는 도착지 후보들은 g-h 간선을 지납니다. 따라서, 최단 경로의 구성을 (s->g) (g-h) (h->d) 혹은 (s->h) (h-g) (g-d)로 나타낼 수 있습니다.
따라서, 만일 (s->d)의 최단거리가 위 경로 구성으로 한 최단거리의 합과 같다면 (g-h) 간선을 무조건 지남을 알 수 있습니다.

**간선 데이터 전처리로 특정하기**
최초에 간선 데이터를 저장할 때 간선의 가중치를 x2 하여 짝수로 만듭니다. 이 때, 간선(g-h)는 -1로 하여 홀수로 만들어줍니다.
만일 (s->d) 최단거리가 홀수라면 (g-h)를 포함하는 것이고 짝수라면 포함하지 않는 것이 됩니다.
이전의 문제 상황에서 최단경로가 2개 이상인 경우에 항상 (g-h)를 포함한 최단경로를 방문하기 때문에 문제를 해결할 수 있습니다.

## 문제 리뷰
<!-- 문제에 대한 후기, 평가 기타 팁과 같이 자유롭게 작성해주세요. -->

간선을 짝,홀로 나뉘어 판단하는 아이디어를 생각하는 것은 굉장히 어려운 것 같습니다.
최단거리의 합으로 간선 포함 여부를 확인하는 방법이 직관적이고 좋은 풀이인 것 같습니다.