### PR TITLE
Solve 2931

### DIFF
--- a/problems/week4/2931/solution_2931_ODG.java
+++ b/problems/week4/2931/solution_2931_ODG.java
@@ -1,0 +1,157 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class Main {
+
+    static BufferedReader in = new BufferedReader(new InputStreamReader(System.in));
+    static int R,C;
+    static char[][] arr;
+    static int[][] visited;
+    static int[] mos,zag;
+
+    static int[] dx = {0,1,0,-1};
+    static int[] dy = {-1,0,1,0};
+
+    static int[][] shapeEntrance = {
+            {1,0,1,0},
+            {0,1,0,1},
+            {1,1,1,1},
+            {0,1,1,0},
+            {1,1,0,0},
+            {1,0,0,1},
+            {0,0,1,1}
+    };
+
+    public static void main(String[] args) throws Exception {
+
+        init();
+
+        Queue<int[]> q = new ArrayDeque<>();
+
+        for(int i=0;i<4;i++) {
+            int gox = mos[1] + dx[i];
+            int goy = mos[0] + dy[i];
+            if(!isIn(goy, gox))continue;
+            if(arr[goy][gox] == 'Z')continue;
+            if(arr[goy][gox] != '.') {
+                int idx = pipeShapeToIdx(arr[goy][gox]);
+                if(shapeEntrance[idx][(i+2)%4] == 1) {
+                    q.add(new int[] {goy,gox});
+                    visited[goy][gox] =1;
+                }
+            }
+        }
+
+        visited[mos[0]][mos[1]] =1;
+
+        int[] stolenPipePos = new int[2];
+
+
+        while(!q.isEmpty()) {
+
+            // 훔친 파이프 위치인 경우
+            int[] curr = q.poll();
+            if(arr[curr[0]][curr[1]] == '.') {
+                stolenPipePos = new int[] {curr[0],curr[1]};
+                break;
+            }
+
+            // BFS
+            int idx = pipeShapeToIdx(arr[curr[0]][curr[1]]);
+            if(idx == -1) {
+                System.out.println(123);
+            }
+
+            for(int i=0;i<4;i++) {
+                if(shapeEntrance[idx][i] == 0)continue;
+
+                int gox = curr[1] + dx[i];
+                int goy = curr[0] + dy[i];
+                if(isIn(goy, gox) && visited[goy][gox] == 0) {
+                    visited[goy][gox] = 1;
+                    q.add(new int[] {goy,gox});
+                }
+            }
+        }
+
+        int[] check = new int[4];
+        for(int i=0;i<4;i++) {
+            int gox = stolenPipePos[1] + dx[i];
+            int goy = stolenPipePos[0] + dy[i];
+            if(isIn(goy, gox) && arr[goy][gox] != '.') {
+                if(arr[goy][gox] =='M' || arr[goy][gox] == 'Z')continue;
+                int idx = pipeShapeToIdx(arr[goy][gox]);
+                if(shapeEntrance[idx][(i+2)%4] == 1) {
+                    check[i] = 1;
+                }
+            }
+        }
+
+        for(int i=0;i<shapeEntrance.length;i++) {
+
+            boolean ok = true;
+            for(int j=0;j<4;j++) {
+                if(shapeEntrance[i][j] != check[j])ok = false;
+            }
+
+            if(ok) {
+                System.out.println((stolenPipePos[0]+1) +" "+(stolenPipePos[1]+1) + " " + idxToPipeShape(i));
+                break;
+            }
+        }
+
+    }
+
+    static boolean isIn(int goy,int gox) {
+        if(gox < 0 || gox >= C || goy < 0 || goy >= R) return false;
+        return true;
+    }
+
+    static void init() throws Exception{
+        StringTokenizer st = new StringTokenizer(in.readLine());
+        R = Integer.parseInt(st.nextToken());
+        C = Integer.parseInt(st.nextToken());
+
+        arr = new char[R][C];
+        visited = new int[R][C];
+        for(int i=0;i<R;i++) {
+            String tmp = in.readLine();
+            for(int j=0;j<C;j++) {
+                arr[i][j] = tmp.charAt(j);
+                if(arr[i][j] == 'M') {
+                    mos = new int[]{i,j};
+                }
+                else if(arr[i][j] == 'Z') {
+                    zag = new int[] {i,j};
+                }
+            }
+        }
+    }
+
+    static int pipeShapeToIdx(char c) {
+        if(c == '|')return 0;
+        if(c == '-')return 1;
+        if(c == '+')return 2;
+        if(c == '1')return 3;
+        if(c == '2')return 4;
+        if(c == '3')return 5;
+        if(c == '4')return 6;
+        else return -1;
+    }
+
+    static char idxToPipeShape(int idx) {
+        if(idx == 0)return '|';
+        if(idx == 1)return '-';
+        if(idx == 2)return '+';
+        if(idx == 3)return '1';
+        if(idx == 4)return '2';
+        if(idx == 5)return '3';
+        if(idx == 6)return '4';
+        else return 0;
+    }
+
+
+}


### PR DESCRIPTION
## 문제 설명
- 문제 출처: [백준](https://www.acmicpc.net/problem/2931)
- 문제 번호: #2931
- 문제 이름: 가스관

## 해결 방법
- 사용한 알고리즘: BFS
- 접근 방법:
### 1.훔친 가스관의 위치를 찾는다.
### 2. 훔친 가스관의 모양을 찾는다.

### 1. 훔친 가스관의 위치를 찾는다.
모스크바(혹은 자그레브)에서 BFS를 시작한다.
인접 칸으로 갈 수 있는 경우* 큐에 넣어 BFS를 돌린다.
BFS로 도달한 칸 중 파이프, 모스크바, 자그레브가 모두 아닌 경우 훔친 파이프의 위치이다.

### 2. 훔친 가스관의 모양을 찾는다.
훔친 가스관의 위치에서 4방탐색을 한 뒤, 갈 수 있는 방향을 체크한 뒤 출력한다.

### 인접 칸으로 갈 수 있는 경우를 체크하는 방법
pipeShapeToIdx(char c) 메서드로 파이프의 모양과 인덱스를 매핑한다.
shapeEntrance[idx][4] 배열을 이용해서 idx 모양의 4방향을 갈 수 있는 지 저장한다.
위, 오른쪽, 아래, 왼쪽 순서로 저장해둔 뒤, 반대 방향을 체크하는 경우 [(i+2)%4]로 체크할 수 있다.
shapeEntrance를 통해 현재 칸에서 인접 칸으로 갈 수 있는지 확인한다.

## 문제 리뷰
배관의 모양을 idx로 매핑하고, idx를 통해 어디로 갈 수 있는 지 미리 저장해놓지 않고,
분기 처리로 한다면 많이 번거로워질 것 같습니다
🐐 ⚽ 
