### PR TITLE
Solve 1956

### DIFF
--- a/problems/week5/1956/solution_1956_sj.java
+++ b/problems/week5/1956/solution_1956_sj.java
@@ -1,0 +1,63 @@
+package baekjoon;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class prob1956 {
+    static final int INF = 10_000_000;
+    static int V, E;
+    static StringTokenizer st = null;
+    static int[][] graph;
+    static int[][] minDistance;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        st = new StringTokenizer(br.readLine());
+        V = Integer.parseInt(st.nextToken());
+        E = Integer.parseInt(st.nextToken());
+
+        graph = new int[V + 1][V + 1];
+        for(int i=1;i<=V;i++){
+            Arrays.fill(graph[i], INF);
+            graph[i][i] = 0;
+        }
+
+        for(int i=0;i<E;i++){
+            st = new StringTokenizer(br.readLine());
+            int s = Integer.parseInt(st.nextToken());
+            int e = Integer.parseInt(st.nextToken());
+            int cost = Integer.parseInt(st.nextToken());
+            graph[s][e] = cost;
+        }
+
+        floydWarshall();
+
+        System.out.println(checkGraph());
+    }
+    private static int checkGraph() {
+        int ret = INF;
+        for(int i=1;i<=V;i++){
+            for(int j=i+1;j<=V;j++){
+                int cycleSum = graph[i][j] + graph[j][i];
+
+                if(cycleSum < INF){
+                    ret = Math.min(ret, cycleSum);
+                }
+            }
+        }
+
+        return ret == INF ? -1 : ret;
+    }
+    private static void floydWarshall() {
+        for(int k=1;k<=V;k++){
+            for(int i=1;i<=V;i++){
+                for(int j=1;j<=V;j++){
+                    graph[i][j] = Math.min(graph[i][j], graph[i][k] + graph[k][j]);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 문제 설명
<!-- 해결하려는 문제에 대한 간략한 설명을 작성합니다. 예를 들어, 문제 출처와 문제 번호, 문제 이름 등을 적습니다. -->
<!-- 각 항목의 내용은 필수가 아닙니다!! 자유롭게 작성해주세요!! -->

- 문제 출처: [백준](https://www.acmicpc.net/problem/1956)
- 문제 번호: #1956
- 문제 이름: 운동

## 해결 방법
<!-- 문제를 해결하기 위해 사용한 알고리즘과 접근 방법을 설명합니다. 주요 아이디어와 알고리즘의 흐름을 간략히 적어주세요. -->

- 사용한 알고리즘: 플로이드 워셜 
- 접근 방법:

문제는 단방향 그래프 입력받습니다. 우리는 단방향 그래프에서 사이클을 찾아야 합니다. 

사이클을 찾으려면 한 노드에서 다른 노드로 이동하여 다시 출발점으로 돌아와야 합니다. 하지만 사이클의 가중치의 합은 최소여야 하기 때문에 우리는 가장 짧은 사이클에만 관심이 있습니다.

즉, 최단거리로 구성되지 않은 사이클은 제외해야 합니다. 최단거리의 알고리즘은 데이크스트라, 벨만포드, 플로이드워셜이 있습니다. 여기서는 모든 노드간의 최단거리를 구하려면 플로이드 워셜이 유효해 보입니다. 플로이드 워셜 알고리즘의 시간복잡도는 V^3입니다. 본 문제의 V는 최대 400이기 때문에 가능해보입니다.

이제는 사이클을 확인해야 합니다. 플로이드 워셜로 경로가 어떻든 최단거리를 구했습니다. 따라서, 출발점 - 목적지 - 출발점 형태의 경로가 있는지만 확인하면 되겠습니다. 경로가 있다면 플로이드 과정에서 최단거리 테이블이 갱신되었을 것이고 아니라면 초기값인 INF로 남아있을 것입니다.

모든 노드를 조사해 사이클 가중치의 최솟값을 출력하면 됩니다.

## 문제 리뷰
<!-- 문제에 대한 후기, 평가 기타 팁과 같이 자유롭게 작성해주세요. -->
플로이드 워셜, 사이클 검출에 대한 개념이 있으면 어렵지 않게 풀이 할 수 있습니다.