### PR TITLE
Solve 16946

### DIFF
--- a/problems/week6/16946/solution_16946_sj.java
+++ b/problems/week6/16946/solution_16946_sj.java
@@ -1,0 +1,191 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class Main {
+    static final int[][] d = { { -1, 0, 1, 0 }, { 0, 1, 0, -1 } };
+
+    static class xy {
+        int x;
+        int y;
+
+        public xy(int x, int y) {
+            this.x = x;
+            this.y = y;
+        }
+
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + x;
+            result = prime * result + y;
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (!(obj instanceof xy)) {
+                return false;
+            }
+
+            xy o = (xy) obj;
+            return this.x == o.x && this.y == o.y;
+        }
+
+    }
+
+    static int N, M;
+    static int[][] board;
+    static StringTokenizer st = null;
+    static xy[][] parents;
+    static boolean[][] visited;
+    static HashMap<Integer, Integer> map;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        map = new HashMap<>();
+        board = new int[N][M];
+        parents = new xy[N][M];
+        visited = new boolean[N][M];
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < M; j++) {
+                parents[i][j] = new xy(i, j);
+            }
+        }
+
+        for (int i = 0; i < N; i++) {
+            String s = br.readLine();
+            for (int j = 0; j < M; j++) {
+                board[i][j] = s.charAt(j) - '0';
+            }
+        }
+
+        FloodFill();
+
+        Print(Solve());
+    }
+
+    private static void Print(int[][] board) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < M; j++) {
+                sb.append(board[i][j]);
+            }
+            sb.append("\n");
+        }
+
+        System.out.println(sb.toString());
+    }
+
+    private static int[][] Solve() {
+        int[][] ret = new int[N][M];
+
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < M; j++) {
+                if (board[i][j] != 1) {
+                    continue;
+                }
+
+                int sum = 0;
+                HashSet<Integer> set = new HashSet<>();
+                for (int k = 0; k < 4; k++) {
+                    int nx = i + d[0][k];
+                    int ny = j + d[1][k];
+
+                    if (IsOutBound(nx, ny) || board[nx][ny] == 1) {
+                        continue;
+                    }
+
+                    int idx = board[nx][ny];
+                    if (!set.contains(idx)) {
+                        set.add(idx);
+                        sum += map.get(idx);
+                    }
+                }
+
+                ret[i][j] = (sum + 1) % 10;
+            }
+        }
+
+        return ret;
+    }
+
+    private static void FloodFill() {
+        int idx = 2;
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < M; j++) {
+                if (visited[i][j] || board[i][j] == 1) {
+                    continue;
+                }
+                bfs(i, j, idx++);
+            }
+        }
+    }
+
+    private static void bfs(int r, int c, int idx) {
+        int cnt = 0;
+        Queue<xy> q = new ArrayDeque<>();
+        q.add(new xy(r, c));
+        visited[r][c] = true;
+        board[r][c] = idx;
+        cnt++;
+
+        while (!q.isEmpty()) {
+            xy cur = q.poll();
+
+            for (int i = 0; i < 4; i++) {
+                int nx = cur.x + d[0][i];
+                int ny = cur.y + d[1][i];
+
+                if (IsOutBound(nx, ny) || visited[nx][ny] || board[nx][ny] != 0) {
+                    continue;
+                }
+
+                xy next = new xy(nx, ny);
+                if (Union(next, cur)) {
+                    cnt++;
+                    q.add(next);
+                    board[nx][ny] = idx;
+                    visited[nx][ny] = true;
+                }
+            }
+        }
+
+        map.put(idx, cnt);
+    }
+
+    private static boolean Union(xy a, xy b) {
+        xy aRoot = Find(a);
+        xy bRoot = Find(b);
+
+        if (aRoot.equals(bRoot)) {
+            return false;
+        }
+
+        parents[b.x][b.y] = aRoot;
+        return true;
+    }
+
+    private static xy Find(xy a) {
+        if (a.equals(parents[a.x][a.y])) {
+            return a;
+        }
+
+        return parents[a.x][a.y] = Find(parents[a.x][a.y]);
+    }
+
+    private static boolean IsOutBound(int nx, int ny) {
+        return nx < 0 || ny < 0 || nx >= N || ny >= M;
+    }
+}


### PR DESCRIPTION
## 문제 설명
<!-- 해결하려는 문제에 대한 간략한 설명을 작성합니다. 예를 들어, 문제 출처와 문제 번호, 문제 이름 등을 적습니다. -->
<!-- 각 항목의 내용은 필수가 아닙니다!! 자유롭게 작성해주세요!! -->

- 문제 출처: [백준](https://www.acmicpc.net/problem/{16946})
- 문제 번호: #16946
- 문제 이름: 벽 부수고 이동하기4

## 해결 방법
<!-- 문제를 해결하기 위해 사용한 알고리즘과 접근 방법을 설명합니다. 주요 아이디어와 알고리즘의 흐름을 간략히 적어주세요. -->

- 사용한 알고리즘: 그래프 탐색
- 접근 방법:

문제가 요구하는 점은 벽이 있는 한점에서 이동할 수 있는 공간의 수를 세는 것입니다. 
직관적으로 생각하면 모든 칸을 탐색하고 만일 벽이라면 그 위치에서 BFS를 수행하는 것입니다.
하지만 그래프가 최대 1000x1000이기 때문에 모든 점을 탐색할 수는 없습니다.

조회할 때 중복되는 부분이 있는지 찾아봤습니다. 
0의 공간 집합을 기준으로 보면 그의 인접한 1들은 모두 같은 공간을 공유합니다.
따라서, 미리 0의 집합과 그의 크기를 구해놓고 1들을 탐색할 때 인접한 0의 집합을 참고하여 공간 크기를 합산할 수 있습니다.

0의 집합은 Union-Find로 구했습니다. BFS를 돌려 갈 수 있는 0끼리 묶고 크기를 저장합니다.
이후에 모든 격자를 탐색하면 1일 때 상,하,좌,우를 보면서 크기를 합산합니다.
그리고 위치한 1 역시 부술 수 있기 때문에 최종적으론 1을 더해줍니다.

## 문제 리뷰
<!-- 문제에 대한 후기, 평가 기타 팁과 같이 자유롭게 작성해주세요. -->
BFS, 분리집합, FloodFill 다양한 개념이 포함된 문제였습니다. 천천히 접근하면 풀만한 문제인 것 같습니다.