### PR TITLE
Solve 2151

### DIFF
--- a/problems/week5/2151/Solution_2151_MW.java
+++ b/problems/week5/2151/Solution_2151_MW.java
@@ -1,0 +1,146 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.PriorityQueue;
+
+import static java.util.Collections.fill;
+
+public class Solution_2151_MW {
+
+    static class Pair implements Comparable<Pair> {
+        int y, x;
+        int dir;
+        int mirrorCnt;
+
+        public Pair(int y, int x, int dir, int mirrorCnt) {
+            this.y = y;
+            this.x = x;
+            this.dir = dir;
+            this.mirrorCnt = mirrorCnt;
+        }
+
+        @Override
+        public int compareTo(Pair o) {
+            return this.mirrorCnt - o.mirrorCnt;
+        }
+    }
+
+    static int n;
+    static char[][] board;
+    static int[] dy = {-1, 0, 1, 0};
+    static int[] dx = {0, -1, 0, 1};
+    static int[][][] vis;
+    static Pair dest;
+
+    public static void main(String[] args) throws Exception {
+
+        // 1. 처음 거울 시작 점에서 4방 탐색 시작
+        // 2. 진행 방향에 거울이 있으면, 2가지 방향 고려해서 큐에 넣기
+        // - 큐에는 위치 설치한 거울 개수, 빛 방향
+        // 3. 설치한 거울의 개수로 다익스트라 돌면서 반대편 거울 발견하면 바로 종료!
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine());
+
+        PriorityQueue<Pair> pq = new PriorityQueue<>();
+
+        board = new char[n][n];
+
+        for (int i = 0; i < n; i++) {
+            String s = br.readLine();
+            for (int j = 0; j < n; j++) {
+                board[i][j] = s.charAt(j);
+            }
+        }
+
+        vis = new int[n][n][4];
+        for(int i=0; i<n; i++) {
+            for(int j=0; j<n; j++) {
+                Arrays.fill(vis[i][j], -1);
+            }
+        }
+        boolean isFirst = true;
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < n; j++) {
+                if (board[i][j] == '#') {
+                    if (isFirst) {
+                        for (int dir = 0; dir < 4; dir++) {
+                            int ny = i + dy[dir];
+                            int nx = j + dx[dir];
+
+                            if (ny < 0 || ny >= n || nx < 0 || nx >= n) continue;
+                            if (board[ny][nx] == '*') continue;
+
+                            if (board[ny][nx] == '!') {
+
+                                pq.offer(new Pair(ny, nx, dir, 0));
+                                vis[ny][nx][dir] = 0;
+
+                                int newDir = (dir + 1) % 4;
+                                pq.offer(new Pair(ny, nx, newDir, 1));
+                                vis[ny][nx][newDir] = 1;
+                                newDir = (dir + 4 - 1) % 4;
+                                pq.offer(new Pair(ny, nx, newDir, 1));
+                                vis[ny][nx][newDir] = 1;
+                            } else {
+                                pq.offer(new Pair(ny, nx, dir, 0));
+                            }
+                        }
+
+                        isFirst = false;
+                    } else {
+                        dest = new Pair(i, j, -1, -1);
+                    }
+                }
+            }
+        }
+
+        while (!pq.isEmpty()) {
+            Pair cur = pq.poll();
+            int y = cur.y;
+            int x = cur.x;
+            int dir = cur.dir;
+            int mirrorCnt = cur.mirrorCnt;
+
+//            System.out.println(y + " " + x + " " + dir);
+
+            if (y == dest.y && x == dest.x) {
+                System.out.println(mirrorCnt);
+                return;
+            }
+
+            int ny = y + dy[dir];
+            int nx = x + dx[dir];
+
+            if (ny < 0 || ny >= n || nx < 0 || nx >= n) continue;
+            if (board[ny][nx] == '*') continue;
+
+            if (board[ny][nx] == '!') {
+
+                if(vis[ny][nx][dir] == -1 || vis[ny][nx][dir] > mirrorCnt) { // (ny, nx)에 거울 설치하지 않는 경우
+                    pq.offer(new Pair(ny, nx, dir, mirrorCnt));
+                }
+
+                int newDir = (dir + 1) % 4;
+                if (vis[ny][nx][newDir] == -1 || vis[ny][nx][newDir] > mirrorCnt + 1) { // (ny, nx)에 거울을 설치하는 경우
+                    // (ny, nx)에 처음 방문 하거나, 같은 좌표에 더 적은 거울 개수로 도착할 수 있을 때
+                    pq.offer(new Pair(ny, nx, newDir, mirrorCnt + 1));
+                    vis[ny][nx][newDir] = mirrorCnt + 1;
+                }
+
+                newDir = (dir + 4 - 1) % 4;
+                if (vis[ny][nx][newDir] == -1 || vis[ny][nx][newDir] > mirrorCnt + 1) { // (ny, nx)에 거울을 설치하는 경우
+                    // (ny, nx)에 처음 방문 하거나, 같은 좌표에 더 적은 거울 개수로 도착할 수 있을 때
+                    pq.offer(new Pair(ny, nx, newDir, mirrorCnt + 1));
+                    vis[ny][nx][newDir] = mirrorCnt + 1;
+                }
+
+            } else { // !가 아닌 경우
+                if (vis[ny][nx][dir] != -1 && vis[ny][nx][dir] <= mirrorCnt) continue; // 같은 좌표에 더 적은 거울 개수로 방문한 적 있으면 pass
+
+                pq.offer(new Pair(ny, nx, dir, mirrorCnt));
+                vis[ny][nx][dir] = mirrorCnt;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 문제 설명
<!-- 해결하려는 문제에 대한 간략한 설명을 작성합니다. 예를 들어, 문제 출처와 문제 번호, 문제 이름 등을 적습니다. -->
<!-- 각 항목의 내용은 필수가 아닙니다!! 자유롭게 작성해주세요!! -->

- 문제 출처: [백준](https://www.acmicpc.net/problem/{2151})
- 문제 번호: #2151
- 문제 이름: 거울 설치

## 해결 방법
<!-- 문제를 해결하기 위해 사용한 알고리즘과 접근 방법을 설명합니다. 주요 아이디어와 알고리즘의 흐름을 간략히 적어주세요. -->

- 사용한 알고리즘: 다익스트라
- 접근 방법:
1. 첫 거울 시작 점에서 4방 탐색 시작
2. 진행 방향에 거울이 있으면, 2가지 방향 고려해서 큐에 넣기 (큐에는 위치, 설치한 거울 개수, 빛 방향을 저장)
3. 설치한 거울의 개수를 기준으로 다익스트라 돌면서 반대편 거울 발견하면 바로 종료
- 주의 할점:
  - !인 경우에도 거울을 설치하지 않을 수 있습니다!
  - **방문 확인은 boolean 배열 대신 int 배열을 사용**하였습니다. **vis[i][j][k]의 의미는 (i, j)에 k의 방향으로 빛이 들어올 때 현재까지 설치한 거울의 개수**입니다. 단순 방문 확인이 아닌 거울의 개수를 저장한 이유는 **(i, j)에 k의 방향으로 빛이 들어오는 경우도 여러 경우가 있을 수 있기 때문**입니다. **빙빙 돌고돌아 해당 좌표의 같은 방향으로 들어왔지만 설치한 거울의 개수는 적을 수 있습니다.** 따라서 **같은 조건(i, j, k)일 때 현재 설치한 거울의 개수보다 적을 경우만 큐에 넣도록 하였습니다.**
  - 방문 확인 할 때 3차원 배열을 쓴 이유는 방향을 고려해서 확인 해주어야 하기 때문입니다. **들어오는 방향에 따라 다음 상황이 달라지기 때문**이죠.

## 문제 리뷰
<!-- 문제에 대한 후기, 평가 기타 팁과 같이 자유롭게 작성해주세요. -->
- 앞의 레이저 통신 문제와 비슷해서 조금 수월하게 풀이한 것 같습니다.