### PR TITLE
Solve 2098

### DIFF
--- a/problems/week6/2098/soilution_2098_sj.java
+++ b/problems/week6/2098/soilution_2098_sj.java
@@ -1,0 +1,58 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class soilution_2098_sj {
+    static final int INF = 1_000_000_000;
+
+    static int N;
+    static int[][] graph;
+    static StringTokenizer st = null;
+    static int[][] dp;
+
+    public static void main(String[] args) throws NumberFormatException, IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        N = Integer.parseInt(br.readLine());
+        graph = new int[N + 1][N + 1];
+
+        for (int i = 1; i <= N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 1; j <= N; j++) {
+                graph[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        dp = new int[N + 1][1 << N];
+        for (int i = 1; i <= N; i++) {
+            Arrays.fill(dp[i], -1);
+        }
+
+        System.out.println(Solve(1, 1));
+    }
+
+    private static int Solve(int cur, int bitState) {
+        if (bitState == (1 << N) - 1) {
+            if (graph[cur][1] == 0) {
+                return INF;
+            } else {
+                return graph[cur][1];
+            }
+        }
+
+        if (dp[cur][bitState] != -1) {
+            return dp[cur][bitState];
+        }
+        dp[cur][bitState] = INF;
+
+        for (int i = 1; i <= N; i++) {
+            if ((bitState & (1 << (i - 1))) == 0 && graph[cur][i] != 0) {
+                dp[cur][bitState] = Math.min(Solve(i, bitState | (1 << (i - 1))) + graph[cur][i], dp[cur][bitState]);
+            }
+        }
+        return dp[cur][bitState];
+    }
+
+}


### PR DESCRIPTION
## 문제 설명
<!-- 해결하려는 문제에 대한 간략한 설명을 작성합니다. 예를 들어, 문제 출처와 문제 번호, 문제 이름 등을 적습니다. -->
<!-- 각 항목의 내용은 필수가 아닙니다!! 자유롭게 작성해주세요!! -->

- 문제 출처: [백준](https://www.acmicpc.net/problem/2098)
- 문제 번호: #2098
- 문제 이름: 외판원 순회

## 해결 방법
<!-- 문제를 해결하기 위해 사용한 알고리즘과 접근 방법을 설명합니다. 주요 아이디어와 알고리즘의 흐름을 간략히 적어주세요. -->

- 사용한 알고리즘: 
- 접근 방법: TSP, 비트마스킹, DP

외판원 순회를 완전탐색으로도 풀 수 있지만 시간복잡도가 충분치 않습니다. N의 모든 경로를 검사하려면 N!이 나오기 때문에 문제서처럼 16인 경우에는 시간이 부족합니다.

외판원 순회 문제는 비트 마스킹은 이용한 DP의 대표 문제입니다. 완전탐색이 불가능한 경우 DP를 사용하고 경로의 문제이기 때문에 비트마스킹으로 경로를 기록합니다.

외판원 순회의 키 포인트는 바로 어느 지점에서 출발해도 결과는 같다는 것입니다. A 지점에서 출발하여 모든 지점을 돌고 다시 A로 돌아온다는 뜻은 한 사이클을 이룬다는 의미이고 이는 최단 경로라면 어느 점에서 출발하는 같은 결과가 나옵니다.

따라서, 보통 출발점을 1로 고정하고 DP를 수행합니다. DP테이블은 2차원 배열로 작성합니다. 첫번째 인덱스는 현재의 도시 N, 두번째 인덱스는 지금까지의 방문정보를 담은 비트 필드입니다.

DP[N + 1][1 << N]
DP[cur][bitState]의 의미는 현재 방문한 노드가 cur, 비트필드가 bitState일 때의 최소비용입니다. 따라서, DP[cur][bitState]의 결과값은 DP[next][newBitState]와의 비교 후 최솟값을 선택하면 됩니다.

기저 부분을 생각해봅시다. 탐색이 끝나는 시점은 모든 노드를 방문했을 때 입니다. 우리는 출발점을 1로 고정했기 때문에 기저에서 현재 노드에서 1로의 경로가 없다면 불가능한 경로 구성이기 때문에 INF를 반환합니다. (최단거리로 선택되지 않기 위함)

경로가 있다면 그 때의 비용을 리턴하면 됩니다.

## 문제 리뷰
<!-- 문제에 대한 후기, 평가 기타 팁과 같이 자유롭게 작성해주세요. -->
외판원 순회는 비트필드를 사용하는 탐색 문제 중에서 가장 유명한 문제입니다. 풀이를 외워두는 것이 좋습니다.