### PR TITLE
Solve 16946, 2098

### DIFF
--- a/problems/week6/16946/Solution_16946_MW.java
+++ b/problems/week6/16946/Solution_16946_MW.java
@@ -1,0 +1,113 @@
+package problems;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.Queue;
+
+public class Solution_16946_MW {
+
+    public static class Pair {
+        public int y, x;
+
+        public Pair(int y, int x) {
+            this.y = y;
+            this.x = x;
+        }
+    }
+
+    static int n, m;
+    static int[][] board;
+    static boolean[] vis;
+    static int[] dy = {-1, 0, 1, 0};
+    static int[] dx = {0, -1, 0, 1};
+    static int num = 1;
+    static int[] map;
+    static StringBuilder sb = new StringBuilder();
+    public static void main(String[] args) throws Exception {
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        String[] s = br.readLine().split(" ");
+        n = Integer.parseInt(s[0]);
+        m = Integer.parseInt(s[1]);
+
+        board = new int[n][m];
+        map = new int[n*m+1];
+        for(int i=0; i<n; i++) {
+            String line = br.readLine();
+            for(int j=0; j<m; j++) {
+                if(line.charAt(j) == '0') {
+                    board[i][j] = 0; // 빈 칸
+                } else {
+                    board[i][j] = -1; // 벽
+                }
+            }
+        }
+
+        // 1. 인접한 0의 지점에 번호 매기기
+        // 2. board 순회하면서 각 지점 번호의 개수 세기 map[num]++
+        // 3. 벽인 자리 인접한 섬이 있으면 개수 더해주기
+
+        for(int i=0; i<n; i++) {
+            for(int j=0; j<m; j++) {
+                if(board[i][j] == 0) {
+                    bfs(i, j);
+                    num++;
+                }
+            }
+        }
+
+        for(int i=0; i<n; i++) {
+            for(int j=0; j<m; j++) {
+                if(board[i][j] != -1) {
+                    sb.append(0);
+                    continue;
+                }
+
+                vis = new boolean[num + 1];
+                int movableCount = 1;
+                for(int dir=0; dir<4; dir++) {
+                    int ny = i + dy[dir];
+                    int nx = j + dx[dir];
+
+                    if(ny < 0 || ny >= n || nx < 0 || nx >= m)  continue;
+                    if(board[ny][nx] == -1) continue;
+                    int landNum = board[ny][nx];
+                    if(vis[landNum])    continue;
+                    vis[landNum] = true;
+                    movableCount += map[landNum];
+                }
+                sb.append(movableCount % 10);
+            }
+            sb.append("\n");
+        }
+
+        System.out.println(sb.toString());
+    }
+
+    private static void bfs(int i, int j) {
+
+        Queue<Pair> q = new ArrayDeque<>();
+        q.offer(new Pair(i, j));
+        board[i][j] = num;
+        int cnt = 1;
+
+        while(!q.isEmpty()) {
+            Pair cur = q.poll();
+
+            for(int dir=0; dir<4; dir++) {
+                int ny = cur.y + dy[dir];
+                int nx = cur.x + dx[dir];
+
+                if(ny < 0 || ny >= n || nx < 0 || nx >= m)  continue;
+                if(board[ny][nx] != 0) continue;
+
+                q.offer(new Pair(ny, nx));
+                board[ny][nx] = num;
+                cnt++;
+            }
+        }
+
+        map[num] = cnt;
+    }
+}

--- a/problems/week6/2098/Solution_2098_MW.java
+++ b/problems/week6/2098/Solution_2098_MW.java
@@ -1,0 +1,53 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+
+public class Solution_2098_MW {
+
+    static int n;
+    static int[][] w;
+    static int[][] d;
+    static final int INF = 1_000_000_000;
+    public static void main(String[] args) throws Exception {
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        n = Integer.parseInt(br.readLine());
+        w = new int[n+1][n+1];
+        d = new int[1<<n][n+1];
+        for(int i=1; i<=n; i++) {
+            String[] s = br.readLine().split(" ");
+            for(int j=1; j<=n; j++) {
+                w[i][j] = Integer.parseInt(s[j-1]);
+            }
+        }
+
+        // d[i][j] = 이미 방문한 도시들의 집합이 i이고, 현재 있는 도시가 j일 때, 방문하지 않은 나머지 도시들을 모두 방문한 뒤 출발 도시로 돌아올 때 드는 최소 비용
+        // 1. 1번 도시에서 모든 도시를 순회하면서 테이블에 기록하기 (dfs + dp)
+        // 2. 만약 이미 값이 있다면 더 이상 순회하지 않고 그 값을 이용
+
+        System.out.println(dfs(1, 1));
+    }
+
+    // 이미 방문한 도시들의 집합이 visited이고 현재 cur을 방문했을 때,
+    // 방문하지 않은 나머지 도시들을 모두 방문한 뒤 출발 도시로 돌아올 때 드는 최소 비용을 반환
+    private static int dfs(int visited, int cur) {
+
+        if(visited == (1<<n) - 1) { // 모든 도시를 방문했을 때 (기저)
+            if(w[cur][1] == 0)  return INF;
+            return w[cur][1];
+        }
+
+        if(d[visited][cur] != 0) { // 이전 방문 도시와 현재 방문한 도시에 대해 나머지 도시들을 모두 방문한 뒤 출발 도시로 돌아올 때 드는 최소 비용이 이미 구해져 있으면..
+            return d[visited][cur];
+        }
+
+        d[visited][cur] = INF;
+        for(int i=0; i<n; i++) { // 다음 도시를 방문
+            if(w[cur][i+1] == 0)    continue; // 연결이 안되어 있으면
+            if((visited & (1<<i)) != 0)  continue; // 이미 방문 했으면
+            d[visited][cur] = Math.min(d[visited][cur], w[cur][i+1] + dfs(visited | (1<<i), i+1));
+        }
+
+        return d[visited][cur];
+    }
+}


### PR DESCRIPTION
## 문제 설명
<!-- 해결하려는 문제에 대한 간략한 설명을 작성합니다. 예를 들어, 문제 출처와 문제 번호, 문제 이름 등을 적습니다. -->
<!-- 각 항목의 내용은 필수가 아닙니다!! 자유롭게 작성해주세요!! -->

- 문제 출처: [백준](https://www.acmicpc.net/problem/{16946})
- 문제 번호: #16946
- 문제 이름: 벽 부수고 이동하기 4

## 해결 방법
<!-- 문제를 해결하기 위해 사용한 알고리즘과 접근 방법을 설명합니다. 주요 아이디어와 알고리즘의 흐름을 간략히 적어주세요. -->

- 사용한 알고리즘: BFS
- 접근 방법
  - 브루트포스 방법으로 모든 벽에서 이동할 모든 벽을 탐색하면 풀 수 없을거라는 예감이 들었습니다. 왜냐하면 (벽의 개수 * 각 벽에서 움직일 수 있는 칸의 개수)가 시간 내에 탐색할 수 없는 경우가 존재할 것 같기 때문입니다. 예를 들어 벽의 개수가 10^4개이고, 각 벽이 이동할 수 있는 칸의 개수가 10^5일 경우 10^9으로 10억이 됩니다.  (정확한 상황에 따른 계산은 생각하기 어려웠습니다.)
  - 따라서 다음 방법으로 풀이 하였습니다.
    1. BFS를 통해 빈 칸인 지점과, 그 지점에서 이동할 수 있는 빈 칸에 번호 매기기 (섬에 번호 매기기)
    2. 해당 번호의 섬을 이루는 원소 개수를 map에 저장하기. map[landNum] = 섬을 이루는 칸의 개수
    3. board를 순회하며 벽일 경우, 인접한 섬을 이루는 칸의 개수 더하기
    4. (i, j) 벽에서 이동할 수 있는 칸의 수를 출력하기

## 문제 리뷰
<!-- 문제에 대한 후기, 평가 기타 팁과 같이 자유롭게 작성해주세요. -->
- 처음에 System.out으로 출력했을 때 시간 초과가 났습니다. **출력이 많을 때 StringBuilder를 사용**해야 겠다는 것을 배웠습니다.
- 이 문제에서 상황에 따른 정확한 시간 복잡도를 구하기 어려웠습니다. 어림잡아 시간 안에 수행을 못할 것이라고 판단하였습니다. 그 근거로는 **벽이 몇 개가 있고, 벽의 위치가 어디인지..에 따라 분명히 시간 안에 수행을 못하는 경우가 있을 것이라고 생각**했기 때문입니다.
- **일반적인 방법으로 풀지 못할 때**는 특히, 시간 초과나 메모리 초과가 날 것 같을 때.. **반대로 생각해서 푸는 문제가 많은 것 같습니다.** 이 문제에서는 **각 벽을 기준으로 BFS를 탐색할 것이 아니라 빈칸을 기준으로 BFS 탐색을 수행하는게 포인트**였습니다.

## 문제 설명
<!-- 해결하려는 문제에 대한 간략한 설명을 작성합니다. 예를 들어, 문제 출처와 문제 번호, 문제 이름 등을 적습니다. -->
<!-- 각 항목의 내용은 필수가 아닙니다!! 자유롭게 작성해주세요!! -->

- 문제 출처: [백준](https://www.acmicpc.net/problem/{2098})
- 문제 번호: #2098
- 문제 이름: 외판원 순회

## 해결 방법
<!-- 문제를 해결하기 위해 사용한 알고리즘과 접근 방법을 설명합니다. 주요 아이디어와 알고리즘의 흐름을 간략히 적어주세요. -->

- 사용한 알고리즘: DFS + DP(memorization)
- 접근 방법
  - 처음 생각했던 풀이 방식으로는 **1. 다익스트라를 통해 모든 정점들 간의 최단거리**를 구해놓고, **2. 순열(DFS)를 통해 방문할 도시의 순서를 결정**해서 **3. 최소값을 갱신**하는 방법을 하면 되지 않을까? 생각했습니다. 하지만 n=16으로 임의의 도시에서 시작하여 다른 **모든 도시의 방문 순서를 결정하는 것은 16!로 시간 내에 수행할 수 없겠다고 판단**하였습니다.
  - 찾아본 방법으로는 dfs + dp를 사용해서 풀 수 있었습니다. 
  - **d[i][j]:** **이미 방문한 도시들의 집합 i, 현재 방문한 도시가 j일 때 방문하지 않은 나머지 도시들을 모두 방문한 뒤 출발 도시로 돌아올 때 드는 최소 비용**
  - **임의의 시작 도시를 선택한 후, 가능한 모든 경우에 대한 노드를 모두 순회**합니다. 하지만 이때 **앞서 동일한 상황(앞서 방문한 도시들)으로 임의의 노드(이번에 방문한 도시)를 탐색한다면 d[i][j]의 값을 return 하고 더 이상 탐색하지 않습니다**. 따라서 **중복된 계산을 피하여 시간 복잡도를 획기적으로 줄이는 방식**입니다.
  - **비트마스킹**을 통해 방문 여부를 효율적으로 확인하였습니다.

## 문제 리뷰
<!-- 문제에 대한 후기, 평가 기타 팁과 같이 자유롭게 작성해주세요. -->
- 재귀의 매운맛을 보았습니다. 프로젝트 마감 후 오랜만에 문제를 푸니 많이 헤맸습니다.. 아무리 바빠도 이틀에 한 문제..는 꼭 풀어야겠습니다.
- 점화식 세우고 for문을 통해 dp테이블을 채우는 방식과 달리, 재귀 + memorization으로 푸는 방식은 아직 익숙하지 않은 것 같습니다. 
- 이 문제에서 INF 값을 Integer.MAX_VALUE로 설정하면 안됩니다. ```d[visited][cur] = Math.min(d[visited][cur], w[cur][i+1] + dfs(visited | (1<<i), i+1));``` 여기서 만약 dfs(visited | (1<<i), i+1)이 Integer.MAX_VALUE를 반환하면 w[cur][i+1] + Integer.MAX_VALUE가 되어 overflow가 발생하기 때문입니다.
- 마지막으로 **최단 거리는 어떤 도시를 시작점으로 해도 동일**합니다. 왜냐하면 **싸이클을 형성**하기 때문