### PR TITLE
Solve 1086

### DIFF
--- a/problems/week6/1086/Solution_1086_sj.java
+++ b/problems/week6/1086/Solution_1086_sj.java
@@ -1,0 +1,93 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+
+public class Main {
+    static int N;
+    static int K;
+    static char[][] arr;
+    static long[][] dp;
+    static int[][] dpRemain;
+
+    public static void main(String[] args) throws NumberFormatException, IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        N = Integer.parseInt(br.readLine());
+        arr = new char[N][];
+        for (int i = 0; i < N; i++) {
+            arr[i] = br.readLine().toCharArray();
+        }
+        K = Integer.parseInt(br.readLine());
+        dp = new long[K][1 << N];
+        dpRemain = new int[K][N];
+
+        for (int i = 0; i < K; i++) {
+            Arrays.fill(dp[i], -1);
+            Arrays.fill(dpRemain[i], -1);
+        }
+
+        long p = dfs(0, 0, 0);
+        long q = fact();
+
+        if (p == 0) {
+            q = 1;
+        } else {
+            long gcd = GCD(q, p);
+            p /= gcd;
+            q /= gcd;
+        }
+
+        System.out.println(p + "/" + q);
+    }
+
+    private static long dfs(int bitState, int remain, int cnt) {
+        if (dp[remain][bitState] != -1) {
+            return dp[remain][bitState];
+        }
+
+        if (cnt == N) {
+            return dp[remain][bitState] = remain == 0 ? 1L : 0;
+        }
+
+        long sum = 0;
+        for (int i = 0; i < N; i++) {
+            if ((bitState & (1 << i)) != 1 << i) {
+                sum += dfs(bitState | (1 << i), getMod(remain, i), cnt + 1);
+            }
+        }
+
+        return dp[remain][bitState] = sum;
+    }
+
+    private static int getMod(int remain, int n) {
+        if (dpRemain[remain][n] != -1) {
+            return dpRemain[remain][n];
+        }
+
+        int now = remain;
+        for (int i = 0; i < arr[n].length; i++) {
+            now *= 10;
+            now = (now + arr[n][i] - '0') % K;
+        }
+
+        return dpRemain[remain][n] = now;
+    }
+
+    private static long GCD(long m, long n) {
+        while (m % n != 0) {
+            long temp = m % n;
+            m = n;
+            n = temp;
+        }
+        return n;
+    }
+
+    private static long fact() {
+        long ret = 1;
+        for (int i = 2; i <= N; i++) {
+            ret *= i;
+        }
+        return ret;
+    }
+}


### PR DESCRIPTION
## 문제 설명
<!-- 해결하려는 문제에 대한 간략한 설명을 작성합니다. 예를 들어, 문제 출처와 문제 번호, 문제 이름 등을 적습니다. -->
<!-- 각 항목의 내용은 필수가 아닙니다!! 자유롭게 작성해주세요!! -->

- 문제 출처: [백준](https://www.acmicpc.net/problem/1086)
- 문제 번호: #1086
- 문제 이름: 박성원

## 해결 방법
<!-- 문제를 해결하기 위해 사용한 알고리즘과 접근 방법을 설명합니다. 주요 아이디어와 알고리즘의 흐름을 간략히 적어주세요. -->

- 사용한 알고리즘: DP, 비트마스킹
- 접근 방법:

DP, 비트마스킹, 나머지 법칙, 최대공약수와 같은 많은 개념이 포함되어 있는 문제입니다.

문제를 이해하기 위해선 나머지 법칙을 이해해야 합니다. 주어진 수들을 이어붙힌 형태는 항상 `a x 10^n' 과 같은 형태이기 때문에 나머지 법칙에 의해서 따로 계산할 수도 있습니다.

완전탐색을 하는 경우 `n!`의 경우가 생기기 때문에 불가능합니다. 따라서, DP로 접근해야 합니다. DP 배열은 2개를 사용했습니다. 
1. `dp[K][1 << N]`: 배치 상태와 나머지의 조합으로 구성한 배열, 그 때의 배치로 순서를 정할 때 1로 떨어지는 경우의 갯수
2. `dpRemain[K][N]` : 나머지가 `K`일 때 `N`을 배치할 때의 나머지 값

1번 배열은 정답을 의미하는 배열입니다. 배치 상태와 나머지만 같으면 내부에서 수들이 어떻게 배치되든 상관없이 같은 값을 가집니다. (나머지 법칙에 의해서) 총 수의 개수가 15개 이하이기 때문에 배치 상태는 비트필드로 표현할 수 있습니다.
2번 배열은 나머지 중복 계산을 피하기 위한 배열입니다. 전체 나머지가 `K`인 상태에서 `N`을 배치할 때 새로운 나머지 값입니다.

dp를 이용해 중복을 제거하면 n!을 재귀로 탐색할 수 있습니다. 재귀의 기저는 현재의 `depth`가 `N`으로 모두 선택됐음을 의미할 때입니다. 그 때의 나머지 값을 확인하여 0이라면 dp값을 1, 아니라면 dp값을 0으로 초기화하고 리턴합니다.

반복문에서는 다음으로 배치 가능한 모든 경우를 탐색합니다. 물론 DP를 통해 중복탐색을 제거합니다. 만일 `i`가 다음 수로 선택된다면 다음 재귀의 파라미터로 배치 상태값, 새로운 나머지, `depth`를 넣습니다.

재귀의 초기 파라미터는 (0, 0, 0)을 줍니다. 이 뜻은 아무 수도 배치하지 않았음을 의미합니다. 그대로 dfs를 수행하면 전체 탐색의 결과를 뽑을 수 있습니다.

여기까지가 분자를 구하는 과정입니다. 분모는 당연하게도 모든 경우인 `N!` 입니다.

분자와 분모를 모두 구했다면 유클리드 호제법으로 기약분수 형태로 출력하면 되겠습니다.

정리하자면,
1. 배치 경우를 탐색하는 dfs 재귀 함수 구현
2. 나머지 법칙에 의해 배치할 때마다 새로운 나머지를 계산 (이 역시도 dp로 중복 계산을 제거)
3. 구한 분자, 분모를 유클리드 호제법으로 기약분수로 나타내기

## 문제 리뷰
<!-- 문제에 대한 후기, 평가 기타 팁과 같이 자유롭게 작성해주세요. -->
문제의 과정이 길고 사용된 개념도 많아 이해하기 어려웠습니다.