### PR TITLE
Solve 12886

### DIFF
--- a/problems/week7/12886/Solution_12886_MW.java
+++ b/problems/week7/12886/Solution_12886_MW.java
@@ -1,0 +1,95 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Queue;
+
+public class Solution_12886_MW {
+
+    public static class Pair {
+        int a, b;
+
+        public Pair(int a, int b) {
+            this.a = a;
+            this.b = b;
+        }
+    }
+
+    static int[] num = new int[3];
+    static boolean[][] vis;
+    public static void main(String[] args) throws IOException {
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        String[] s = br.readLine().split(" ");
+        num[0] = Integer.parseInt(s[0]);
+        num[1] = Integer.parseInt(s[1]);
+        num[2] = Integer.parseInt(s[2]);
+        int sum = Arrays.stream(num).sum();
+        vis = new boolean[sum+1][sum+1];
+        // 전체 합이 sum으로 일정하므로, 각각의 돌은 sum을 넘을 수 없음.
+        // 최악의 시간 복잡도는 vis 배열이 모두 true가 될 때까지 탐색하는 것이므로, a, b, c가 모두 500이라고 가정할 때
+        // 대략 1500 * 1500 = 2,250,000이 상한 값
+
+        if(sum % 3 != 0) {
+            System.out.println(0);
+            return;
+        }
+
+        Queue<Pair> q = new ArrayDeque<>();
+        for(int i=0; i<3; i++) {
+            for(int j=i+1; j<3; j++) {
+                int a = num[i];
+                int b = num[j];
+                int mx = Math.max(a, b);
+                int mn = Math.min(a, b);
+
+                if(vis[mn][mx]) continue;
+
+                vis[mn][mx] = true;
+                q.offer(new Pair(mn, mx));
+            }
+        }
+
+        while(!q.isEmpty()) {
+            Pair cur = q.poll();
+            int a = cur.a;
+            int b = cur.b;
+            int c = sum - (cur.a + cur.b);
+
+            if(a == b && b == c) {
+                System.out.println(1);
+                return;
+            }
+
+            // a, b
+            int x = Math.min(a, b);
+            int y = Math.max(a, b);
+            y -= x;
+            x *= 2;
+            if(vis[x][y]) continue;
+            vis[x][y] = true;
+            q.offer(new Pair(x, y));
+
+            // b, c
+            x = Math.min(b, c);
+            y = Math.max(b, c);
+            y -= x;
+            x *= 2;
+            if(vis[x][y]) continue;
+            vis[x][y] = true;
+            q.offer(new Pair(x, y));
+
+            // a, c
+            x = Math.min(a, c);
+            y = Math.max(a, c);
+            y -= x;
+            x *= 2;
+            if(vis[x][y]) continue;
+            vis[x][y] = true;
+            q.offer(new Pair(x, y));
+        }
+
+        System.out.println(0);
+    }
+}


### PR DESCRIPTION
## 문제 설명
<!-- 해결하려는 문제에 대한 간략한 설명을 작성합니다. 예를 들어, 문제 출처와 문제 번호, 문제 이름 등을 적습니다. -->
<!-- 각 항목의 내용은 필수가 아닙니다!! 자유롭게 작성해주세요!! -->

- 문제 출처: [백준](https://www.acmicpc.net/problem/12866)
- 문제 번호: #12866
- 문제 이름: 돌 그룹

## 해결 방법
<!-- 문제를 해결하기 위해 사용한 알고리즘과 접근 방법을 설명합니다. 주요 아이디어와 알고리즘의 흐름을 간략히 적어주세요. -->

- 사용한 알고리즘: BFS
- 접근 방법: 
  - **중요한 부분은 x+x, y-x로 총합은 유지**됩니다. 따라서 **매번 3개 중 2개를 고르기만 하면 된다**고 생각했습니다. **BFS**를 통해 매번 가능한 경우를 큐에 넣어줍니다. 가능한 경우는 다음과 같습니다.
    - a, b
    - b, c
    - a, c 
  - 하지만 안되는 케이스는 **무한 루프에 빠질 수도 있기 때문에 방문 처리**를 해야 합니다.
    - 고른 두 개의 값에서 **vis[최소값][최대값]으로 방문 처리**를 해주었습니다. **두 개의 값이 결정된다면 전체 합이 일정하므로 나머지 하나는 상수**이기 때문입니다.
    - 여기서 **시간 복잡도의 상한**을 구할 수 있습니다. 초기 a, b, c값이 모두 500이라면 sum = 1500이 되고, **2차원 방문 배열 vis[1500][1500]을 모두 방문하는 것이 최악의 케이스**입니다. 따라서 1500 * 1500 = 2,250,000 즉, **대략 2백만** 정도 됩니다.
    - 여기서 **각 수가 계산 과정에서 1500을 넘을 수 있지 않을까** 생각했지만, **몇 번 연산을 하든 전체 합이 sum으로 고정**이므로 **각각의 그룹의 돌의 수는 sum을 넘을 수 없습니다.**

## 문제 리뷰
<!-- 문제에 대한 후기, 평가 기타 팁과 같이 자유롭게 작성해주세요. -->
- 어려웠습니다. 
  - 시간 복잡도 계산을 어떻게 해야할지 감이 안잡혔습니다. `bfs의 경우 방문 배열의 크기를 활용하면 상한을 구할 수 있겠다`라는 점을 배웠습니다.
  - x+x, y-x이기 때문에 `전체 합이 항상 유지`된다는 것을 처음 풀이할 때 발견하지 못했습니다.
  - vis 배열의 크기를 어느정도로 해야할지 감이 안왔습니다. `각각의 수는 전체 합을 넘을 수 없다`가 핵심이라고 생각합니다.
